### PR TITLE
Add documentation directory for web publishing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,3 +342,12 @@ Or via URI query parameters:
 occystrap process "registry://registry-1.docker.io/library/busybox:latest?os=linux&arch=arm64&variant=v8" \
     dir://busybox
 ```
+
+## Documentation
+
+For more detailed documentation, see the [docs/](docs/) directory:
+
+- [Installation](docs/installation.md) - Getting started guide
+- [Command Reference](docs/command-reference.md) - Complete CLI reference
+- [Pipeline Architecture](docs/pipeline.md) - How the pipeline works
+- [Use Cases](docs/use-cases.md) - Common scenarios and examples

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,361 @@
+# Command Reference
+
+This document provides a complete reference for Occy Strap's command-line
+interface.
+
+## Global Options
+
+These options apply to all commands and must be specified before the command
+name:
+
+| Option | Environment Variable | Description |
+|--------|---------------------|-------------|
+| `--verbose` | | Enable debug logging |
+| `--os OSNAME` | | Target operating system (default: linux) |
+| `--architecture ARCH` | | Target CPU architecture (default: amd64) |
+| `--variant VARIANT` | | CPU variant (e.g., v8 for ARM) |
+| `--username USER` | `OCCYSTRAP_USERNAME` | Registry authentication username |
+| `--password PASS` | `OCCYSTRAP_PASSWORD` | Registry authentication password |
+| `--insecure` | | Use HTTP instead of HTTPS for registries |
+
+Example:
+
+```bash
+occystrap --verbose --architecture arm64 --variant v8 \
+    process registry://docker.io/library/busybox:latest tar://busybox.tar
+```
+
+## Commands
+
+### process
+
+The primary command for processing container images through the pipeline.
+
+```bash
+occystrap process SOURCE DESTINATION [-f FILTER]...
+```
+
+**Arguments:**
+
+- `SOURCE` - Input URI specifying where to read the image from
+- `DESTINATION` - Output URI specifying where to write the image to
+- `-f FILTER` - Optional filter(s) to apply (can be specified multiple times)
+
+**Examples:**
+
+```bash
+# Registry to tarball
+occystrap process registry://docker.io/library/busybox:latest tar://busybox.tar
+
+# Registry to directory with filters
+occystrap process registry://docker.io/library/python:3.11 dir://python \
+    -f normalize-timestamps -f "exclude:pattern=**/__pycache__/**"
+
+# Docker daemon to registry
+occystrap process docker://myimage:v1 registry://myregistry.com/myimage:v1
+```
+
+### search
+
+Search for files within container image layers.
+
+```bash
+occystrap search SOURCE PATTERN [--regex] [--script-friendly]
+```
+
+**Arguments:**
+
+- `SOURCE` - Input URI specifying the image to search
+- `PATTERN` - Glob pattern or regex to match against file paths
+
+**Options:**
+
+- `--regex` - Treat PATTERN as a regular expression instead of a glob
+- `--script-friendly` - Output in machine-parseable format
+
+**Examples:**
+
+```bash
+# Search for shell binaries
+occystrap search registry://docker.io/library/busybox:latest "bin/*sh"
+
+# Search with regex
+occystrap search --regex docker://python:3.11 ".*\.py$"
+
+# Machine-parseable output
+occystrap search --script-friendly tar://image.tar "*.conf"
+```
+
+## Input URI Schemes
+
+### registry://
+
+Fetch images from Docker/OCI registries via HTTP API.
+
+```
+registry://[user:pass@]HOST/IMAGE:TAG[?options]
+```
+
+**Query Options:**
+
+| Option | Description |
+|--------|-------------|
+| `arch=ARCH` | CPU architecture (overrides global) |
+| `os=OS` | Operating system (overrides global) |
+| `variant=VAR` | CPU variant (overrides global) |
+| `insecure=true` | Use HTTP instead of HTTPS |
+
+**Examples:**
+
+```bash
+# Docker Hub
+registry://docker.io/library/busybox:latest
+registry://registry-1.docker.io/library/python:3.11
+
+# GitHub Container Registry
+registry://ghcr.io/myorg/myimage:v1
+
+# Private registry
+registry://myregistry.example.com/myproject/myimage:latest
+
+# With architecture selection
+registry://docker.io/library/busybox:latest?os=linux&arch=arm64&variant=v8
+```
+
+### docker://
+
+Fetch images from the local Docker or Podman daemon.
+
+```
+docker://IMAGE:TAG[?socket=/path/to/socket]
+```
+
+**Query Options:**
+
+| Option | Description |
+|--------|-------------|
+| `socket=/path` | Custom daemon socket path |
+
+**Examples:**
+
+```bash
+# Docker daemon (default socket)
+docker://myimage:v1
+
+# Podman (rootful)
+docker://myimage:v1?socket=/run/podman/podman.sock
+
+# Podman (rootless)
+docker://myimage:v1?socket=/run/user/1000/podman/podman.sock
+```
+
+### tar://
+
+Read images from docker-save format tarballs.
+
+```
+tar:///path/to/file.tar
+```
+
+**Examples:**
+
+```bash
+tar:///home/user/images/busybox.tar
+tar://./local-image.tar
+```
+
+## Output URI Schemes
+
+### tar://
+
+Create docker-loadable tarballs (v1.2 format).
+
+```
+tar:///path/to/output.tar
+```
+
+The resulting tarball can be loaded with `docker load -i output.tar`.
+
+### dir://
+
+Extract images to a directory.
+
+```
+dir:///path/to/directory[?options]
+```
+
+**Query Options:**
+
+| Option | Description |
+|--------|-------------|
+| `unique_names=true` | Enable layer deduplication across images |
+| `expand=true` | Expand layer tarballs to filesystem |
+
+**Examples:**
+
+```bash
+# Simple extraction
+dir://./extracted
+
+# With layer deduplication (for multiple images)
+dir://./shared?unique_names=true
+
+# Expanded layers for inspection
+dir://./inspect?expand=true
+```
+
+### oci://
+
+Create OCI runtime bundles for use with runc.
+
+```
+oci:///path/to/bundle
+```
+
+The bundle can be run with `runc run <container-id>`.
+
+### mounts://
+
+Create overlay mount-based extraction using extended attributes.
+
+```
+mounts:///path/to/directory
+```
+
+### docker://
+
+Load images into the local Docker or Podman daemon.
+
+```
+docker://IMAGE:TAG[?socket=/path/to/socket]
+```
+
+**Examples:**
+
+```bash
+# Load into Docker
+docker://myimage:v1
+
+# Load into Podman
+docker://myimage:v1?socket=/run/podman/podman.sock
+```
+
+### registry://
+
+Push images to Docker/OCI registries.
+
+```
+registry://HOST/IMAGE:TAG[?insecure=true]
+```
+
+**Examples:**
+
+```bash
+# Push to private registry
+registry://myregistry.example.com/myproject/myimage:v1
+
+# Push with insecure (HTTP)
+registry://internal.local/image:tag?insecure=true
+```
+
+## Filters
+
+Filters transform or inspect image elements as they pass through the pipeline.
+Multiple filters can be chained using multiple `-f` options.
+
+### normalize-timestamps
+
+Normalize file modification times in layer tarballs for reproducible builds.
+
+```
+normalize-timestamps
+normalize-timestamps:ts=TIMESTAMP
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `ts=TIMESTAMP` | Unix timestamp to use (default: 0, Unix epoch) |
+
+When timestamps are normalized, layer SHA256 hashes are recalculated and the
+manifest is updated.
+
+**Examples:**
+
+```bash
+# Normalize to Unix epoch
+-f normalize-timestamps
+
+# Normalize to specific timestamp (Jan 1, 2021)
+-f "normalize-timestamps:ts=1609459200"
+```
+
+### search
+
+Search for files matching a pattern while processing.
+
+```
+search:pattern=PATTERN[,regex=true][,script_friendly=true]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `pattern=PATTERN` | Glob or regex pattern to match |
+| `regex=true` | Treat pattern as regex instead of glob |
+| `script_friendly=true` | Machine-parseable output format |
+
+When used as a filter, search prints matches AND passes elements to the output.
+
+**Examples:**
+
+```bash
+# Search while creating tarball
+-f "search:pattern=*.conf"
+
+# Search with regex
+-f "search:pattern=.*\.py$,regex=true"
+```
+
+### exclude
+
+Exclude files matching glob patterns from image layers.
+
+```
+exclude:pattern=PATTERN[,PATTERN2,...]
+```
+
+Files matching the patterns are removed from layers. Layer hashes are
+recalculated after modification.
+
+**Examples:**
+
+```bash
+# Exclude git directories
+-f "exclude:pattern=**/.git/**"
+
+# Exclude multiple patterns
+-f "exclude:pattern=**/.git/**,**/__pycache__/**,**/*.pyc"
+```
+
+## Legacy Commands
+
+The following commands are deprecated but still available for backwards
+compatibility. Use the `process` and `search` commands instead.
+
+| Legacy Command | New Equivalent |
+|----------------|----------------|
+| `fetch-to-tarfile REG IMG TAG FILE` | `process registry://REG/IMG:TAG tar://FILE` |
+| `fetch-to-extracted REG IMG TAG DIR` | `process registry://REG/IMG:TAG dir://DIR` |
+| `fetch-to-oci REG IMG TAG DIR` | `process registry://REG/IMG:TAG oci://DIR` |
+| `fetch-to-mounts REG IMG TAG DIR` | `process registry://REG/IMG:TAG mounts://DIR` |
+| `tarfile-to-extracted FILE DIR` | `process tar://FILE dir://DIR` |
+| `docker-to-tarfile IMG TAG FILE` | `process docker://IMG:TAG tar://FILE` |
+| `docker-to-extracted IMG TAG DIR` | `process docker://IMG:TAG dir://DIR` |
+| `docker-to-oci IMG TAG DIR` | `process docker://IMG:TAG oci://DIR` |
+| `search-layers REG IMG TAG PAT` | `search registry://REG/IMG:TAG PAT` |
+| `search-layers-tarfile FILE PAT` | `search tar://FILE PAT` |
+| `search-layers-docker IMG TAG PAT` | `search docker://IMG:TAG PAT` |
+| `recreate-image DIR IMG TAG FILE` | `process dir://DIR tar://FILE` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,90 @@
+# Occy Strap Documentation
+
+Occy Strap is a Docker/OCI container image manipulation toolkit that allows you
+to work with container images without requiring Docker to be installed. It
+follows a flexible **input -> filter -> output** pipeline pattern for processing
+container images.
+
+## What Can Occy Strap Do?
+
+- **Download images** from Docker registries, local Docker/Podman daemons, or
+  existing tarballs
+- **Transform images** using filters (normalize timestamps, exclude files,
+  search for content)
+- **Export images** to tarballs, directories, OCI runtime bundles, or push to
+  registries
+- **Search images** for files matching glob or regex patterns
+
+## Quick Example
+
+```bash
+# Download an image from Docker Hub to a tarball
+occystrap process registry://docker.io/library/busybox:latest tar://busybox.tar
+
+# Search for shell binaries in an image
+occystrap search registry://docker.io/library/busybox:latest "bin/*sh"
+
+# Download with timestamp normalization for reproducible builds
+occystrap process registry://docker.io/library/python:3.11 tar://python.tar \
+    -f normalize-timestamps
+```
+
+## Documentation Index
+
+### Getting Started
+
+- [Installation](installation.md) - How to install Occy Strap and verify it's
+  working
+
+### Reference
+
+- [Command Reference](command-reference.md) - Complete CLI commands, options,
+  URI schemes, and filters
+- [Pipeline Architecture](pipeline.md) - Understanding inputs, filters, and
+  outputs
+
+### Guides
+
+- [Use Cases](use-cases.md) - Common scenarios and examples
+
+## Key Concepts
+
+### URI-Style Commands
+
+Occy Strap uses URI-style arguments for specifying sources and destinations:
+
+```bash
+occystrap process SOURCE DESTINATION [-f FILTER]...
+```
+
+Input URIs specify where to get images:
+- `registry://docker.io/library/busybox:latest` - Docker/OCI registry
+- `docker://myimage:v1` - Local Docker daemon
+- `tar:///path/to/image.tar` - Existing tarball
+
+Output URIs specify where to write images:
+- `tar:///path/to/output.tar` - Docker-loadable tarball
+- `dir:///path/to/directory` - Extracted directory
+- `oci:///path/to/bundle` - OCI runtime bundle
+- `registry://myregistry.com/image:tag` - Push to registry
+
+### Pipeline Pattern
+
+```
+Input Source  -->  Filter Chain (optional)  -->  Output Writer  -->  Files
+```
+
+Filters transform or inspect image elements as they flow through the pipeline.
+Multiple filters can be chained together.
+
+## Requirements
+
+- Python 3.6+
+- No Docker installation required (works independently)
+- For registry access: network connectivity to the registry
+- For local Docker access: running Docker daemon with accessible socket
+
+## Links
+
+- [GitHub Repository](https://github.com/shakenfist/occystrap)
+- [Shaken Fist Project](https://shakenfist.com)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,133 @@
+# Installation
+
+This guide covers installing Occy Strap and verifying it's working correctly.
+
+## Requirements
+
+- Python 3.7 or later
+- pip (Python package manager)
+- Network access to container registries (for downloading images)
+- Optionally: Docker or Podman daemon (for local image operations)
+
+## Installation from PyPI
+
+The simplest way to install Occy Strap is via pip:
+
+```bash
+pip install occystrap
+```
+
+## Installation from Source
+
+To install the latest development version:
+
+```bash
+git clone https://github.com/shakenfist/occystrap.git
+cd occystrap
+pip install -e .
+```
+
+## Verifying the Installation
+
+After installation, verify that Occy Strap is working:
+
+```bash
+# Check the version
+occystrap --help
+
+# Try downloading a small image
+occystrap process registry://docker.io/library/hello-world:latest \
+    tar://hello-world.tar
+
+# Verify the tarball was created
+ls -la hello-world.tar
+```
+
+## Dependencies
+
+Occy Strap depends on the following Python packages (installed automatically):
+
+| Package | Purpose |
+|---------|---------|
+| click | Command-line interface framework |
+| requests | HTTP client for registry API |
+| requests-unixsocket | Unix socket support for Docker daemon |
+| prettytable | Formatted table output |
+| oslo.concurrency | Concurrency utilities |
+| shakenfist-utilities | Shared utilities |
+
+## Platform Support
+
+Occy Strap is primarily designed for Linux systems. It may work on other
+platforms with Python support, but has been tested on:
+
+- Ubuntu 20.04, 22.04
+- CentOS 7, 8
+- Debian 10, 11
+
+## Optional: Docker/Podman Socket Access
+
+To use Occy Strap with local Docker or Podman images, you need access to the
+daemon socket:
+
+### Docker
+
+The Docker socket is typically at `/var/run/docker.sock`. Your user needs to be
+in the `docker` group:
+
+```bash
+sudo usermod -aG docker $USER
+# Log out and back in for group membership to take effect
+```
+
+### Podman
+
+Podman doesn't run a daemon by default. Enable the socket service:
+
+```bash
+# For rootless Podman (recommended)
+systemctl --user start podman.socket
+
+# For rootful Podman
+sudo systemctl start podman.socket
+```
+
+The rootless socket is at `/run/user/<uid>/podman/podman.sock`, and the rootful
+socket is at `/run/podman/podman.sock`.
+
+## Troubleshooting
+
+### Permission Denied on Docker Socket
+
+If you see "Permission denied" errors when accessing the Docker socket:
+
+```bash
+# Add your user to the docker group
+sudo usermod -aG docker $USER
+
+# Log out and back in, or use newgrp
+newgrp docker
+```
+
+### SSL Certificate Errors
+
+If you encounter SSL certificate verification errors with private registries:
+
+```bash
+# Use the --insecure flag
+occystrap --insecure process registry://myregistry.local/image:tag tar://out.tar
+```
+
+### Connection Refused to Registry
+
+Ensure the registry hostname is correct and network access is available:
+
+```bash
+# Test connectivity
+curl -v https://registry-1.docker.io/v2/
+```
+
+## Next Steps
+
+- [Command Reference](command-reference.md) - Learn the CLI commands
+- [Use Cases](use-cases.md) - Common scenarios and examples

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,261 @@
+# Pipeline Architecture
+
+Occy Strap processes container images using a flexible pipeline pattern. This
+document explains how the pipeline works and how its components interact.
+
+## Overview
+
+The pipeline follows a simple flow:
+
+```
+Input Source  -->  Filter Chain (optional)  -->  Output Writer  -->  Files
+```
+
+1. **Input Source** reads image elements (config and layers) from a source
+2. **Filters** transform or inspect elements as they pass through
+3. **Output Writer** writes the processed elements to their destination
+
+## Image Elements
+
+Container images consist of two types of elements:
+
+| Element Type | Description |
+|--------------|-------------|
+| `CONFIG_FILE` | JSON file containing image metadata and configuration |
+| `IMAGE_LAYER` | Tarball containing a filesystem layer |
+
+Each element flows through the pipeline independently, allowing streaming
+processing without loading entire images into memory.
+
+## Input Sources
+
+Input sources implement the `ImageInput` interface and provide image elements
+from various sources.
+
+### Registry Input
+
+Fetches images from Docker/OCI registries using the HTTP API.
+
+```
+registry://HOST/IMAGE:TAG
+```
+
+Capabilities:
+- Token-based and basic authentication
+- Multi-architecture image selection
+- Manifest parsing (v1, v2, OCI formats)
+- Individual layer blob fetching
+
+### Docker Daemon Input
+
+Fetches images from local Docker or Podman daemons.
+
+```
+docker://IMAGE:TAG
+```
+
+Uses the Docker Engine API over Unix socket. The entire image is streamed
+(equivalent to `docker save`), then parsed on the fly.
+
+**Note:** The Docker Engine API only provides complete image export - there's
+no way to fetch individual layers separately. This is a limitation of the API
+design.
+
+### Tarball Input
+
+Reads images from existing docker-save format tarballs.
+
+```
+tar:///path/to/file.tar
+```
+
+Parses `manifest.json` to locate config files and layers within the tarball.
+
+## Filters
+
+Filters implement the decorator pattern, wrapping outputs (or other filters)
+to transform or inspect elements. They inherit from `ImageFilter`.
+
+### How Filters Work
+
+```python
+# Conceptual filter structure
+class MyFilter(ImageFilter):
+    def __init__(self, wrapped_output):
+        self.wrapped = wrapped_output
+
+    def process_image_element(self, element_type, name, data):
+        # Transform the element
+        modified_data = transform(data)
+        modified_name = new_name_if_changed
+
+        # Pass to wrapped output
+        self.wrapped.process_image_element(element_type, modified_name,
+                                           modified_data)
+```
+
+### Filter Capabilities
+
+Filters can:
+
+- **Transform data** - Modify element content (e.g., normalize timestamps)
+- **Transform names** - Rename elements (e.g., after hash changes)
+- **Inspect elements** - Read without modification (e.g., search)
+- **Skip elements** - Exclude elements from output
+- **Accumulate state** - Track information across elements
+
+### Available Filters
+
+**normalize-timestamps**: Rewrites layer tarballs to set all file modification
+times to a consistent value. Since this changes content, SHA256 hashes are
+recalculated.
+
+**search**: Searches layer contents for files matching patterns. Can operate
+as search-only (prints results) or passthrough (searches AND forwards
+elements).
+
+**exclude**: Removes files matching glob patterns from layers, recalculating
+hashes afterward.
+
+### Chaining Filters
+
+Multiple filters are chained together:
+
+```bash
+occystrap process registry://... tar://output.tar \
+    -f normalize-timestamps \
+    -f "search:pattern=*.conf" \
+    -f "exclude:pattern=**/.git/**"
+```
+
+The pipeline becomes:
+
+```
+Input --> normalize-timestamps --> search --> exclude --> Output
+```
+
+Each filter wraps the next, forming a chain that processes elements in order.
+
+## Output Writers
+
+Output writers implement the `ImageOutput` interface and handle the final
+destination of processed elements.
+
+### Tarball Output
+
+Creates docker-loadable tarballs in v1.2 format.
+
+```
+tar:///path/to/output.tar
+```
+
+The tarball contains:
+- `manifest.json` - Image manifest
+- `<hash>.json` - Config file
+- `<hash>/layer.tar` - Layer tarballs
+
+Can be loaded with `docker load -i output.tar`.
+
+### Directory Output
+
+Extracts images to directories.
+
+```
+dir:///path/to/directory
+```
+
+Options:
+- `unique_names=true` - Enable layer deduplication by prefixing filenames
+- `expand=true` - Extract layer tarballs to filesystem
+
+With `unique_names`, a `catalog.json` tracks which layers belong to which
+images, allowing multiple images to share storage.
+
+### OCI Bundle Output
+
+Creates OCI runtime bundles for runc.
+
+```
+oci:///path/to/bundle
+```
+
+Produces:
+- `config.json` - OCI runtime configuration
+- `rootfs/` - Merged filesystem from all layers
+
+### Registry Output
+
+Pushes images to Docker/OCI registries.
+
+```
+registry://HOST/IMAGE:TAG
+```
+
+Uploads layers as blobs and creates the manifest.
+
+### Docker Daemon Output
+
+Loads images into local Docker or Podman.
+
+```
+docker://IMAGE:TAG
+```
+
+Uses the Docker Engine API to load the image.
+
+## Data Flow Example
+
+Consider this command:
+
+```bash
+occystrap process registry://docker.io/library/busybox:latest \
+    tar://busybox.tar -f normalize-timestamps
+```
+
+The data flow is:
+
+```
+1. Registry Input fetches manifest from docker.io
+2. Registry Input yields CONFIG_FILE element
+   --> TimestampNormalizer passes through unchanged
+   --> TarWriter writes to tarball
+3. For each layer:
+   a. Registry Input fetches layer blob
+   b. Registry Input yields IMAGE_LAYER element
+   c. TimestampNormalizer rewrites tarball with epoch timestamps
+   d. TimestampNormalizer recalculates SHA256
+   e. TimestampNormalizer yields modified element with new name
+   f. TarWriter writes modified layer to tarball
+4. TarWriter.finalize() writes manifest.json
+```
+
+## Key Concepts
+
+### Whiteout Files
+
+OCI layers use special files to mark deletions:
+
+- `.wh.<filename>` - Marks a specific file as deleted
+- `.wh..wh..opq` - Marks entire directory as opaque (replaced)
+
+These are processed when extracting layers with `expand=true`.
+
+### Layer Deduplication
+
+With `unique_names=true`, layers are stored with content-addressed names.
+When downloading multiple images:
+
+1. First image stores layers normally
+2. Subsequent images check if layers already exist
+3. Shared layers are referenced, not duplicated
+4. `catalog.json` maps images to their layers
+
+### Hash Recalculation
+
+When filters modify layer content (timestamps, file exclusion), the SHA256
+hash changes. Filters that modify content:
+
+1. Process the layer tarball
+2. Calculate the new SHA256 hash
+3. Update the layer name to use the new hash
+4. Update the manifest to reference the new hash

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,314 @@
+# Use Cases
+
+This document covers common scenarios for using Occy Strap with practical
+examples.
+
+## Airgapped Environments
+
+Transfer container images to systems without internet access.
+
+### Download Images for Transfer
+
+```bash
+# Download multiple images to tarballs
+occystrap process registry://docker.io/library/python:3.11 tar://python.tar
+occystrap process registry://docker.io/library/nginx:latest tar://nginx.tar
+occystrap process registry://docker.io/library/postgres:15 tar://postgres.tar
+```
+
+### Load Images on Airgapped System
+
+```bash
+# On the airgapped system with Docker
+docker load -i python.tar
+docker load -i nginx.tar
+docker load -i postgres.tar
+```
+
+## Reproducible Builds
+
+Create images with consistent hashes regardless of build time.
+
+### Normalize Timestamps
+
+```bash
+# Download with timestamp normalization (Unix epoch)
+occystrap process registry://docker.io/library/busybox:latest \
+    tar://busybox.tar -f normalize-timestamps
+
+# Verify hash is consistent
+sha256sum busybox.tar
+# Running again produces the same hash
+```
+
+### Use Specific Timestamp
+
+```bash
+# Normalize to a specific date (Jan 1, 2024)
+occystrap process registry://docker.io/library/python:3.11 \
+    tar://python.tar -f "normalize-timestamps:ts=1704067200"
+```
+
+## Container Forensics
+
+Inspect and analyze container image contents.
+
+### Search for Configuration Files
+
+```bash
+# Find all .conf files
+occystrap search registry://docker.io/library/nginx:latest "*.conf"
+
+# Find all Python files with regex
+occystrap search --regex docker://myapp:v1 ".*\.py$"
+
+# Machine-readable output for scripting
+occystrap search --script-friendly tar://image.tar "*.sh" > shell_files.txt
+```
+
+### Extract and Inspect Layers
+
+```bash
+# Extract with expanded layers for inspection
+occystrap process registry://docker.io/library/python:3.11 \
+    "dir://python-inspect?expand=true"
+
+# Browse the extracted filesystem
+ls -la python-inspect/
+find python-inspect -name "*.conf"
+```
+
+### Search While Processing
+
+```bash
+# Search for config files while creating tarball
+occystrap process registry://docker.io/library/nginx:latest \
+    tar://nginx.tar -f "search:pattern=etc/**/*.conf"
+```
+
+## Private Registry Operations
+
+Work with authenticated registries.
+
+### Download from Private Registry
+
+```bash
+# Using command-line options
+occystrap --username myuser --password mytoken \
+    process registry://registry.gitlab.com/mygroup/myimage:latest \
+    tar://myimage.tar
+
+# Using environment variables (more secure)
+export OCCYSTRAP_USERNAME=myuser
+export OCCYSTRAP_PASSWORD=mytoken
+occystrap process registry://registry.gitlab.com/mygroup/myimage:latest \
+    tar://myimage.tar
+```
+
+### Mirror Images Between Registries
+
+```bash
+# Copy from Docker Hub to private registry
+occystrap --username destuser --password desttoken \
+    process registry://docker.io/library/nginx:latest \
+    registry://myregistry.example.com/mirror/nginx:latest
+
+# Copy from local Docker to registry
+occystrap --username myuser --password mytoken \
+    process docker://myapp:v1 \
+    registry://ghcr.io/myorg/myapp:v1
+```
+
+## Multi-Architecture Images
+
+Work with images for different CPU architectures.
+
+### Download ARM64 Image
+
+```bash
+# Using global options
+occystrap --os linux --architecture arm64 --variant v8 \
+    process registry://docker.io/library/busybox:latest \
+    tar://busybox-arm64.tar
+
+# Using URI query parameters
+occystrap process \
+    "registry://docker.io/library/busybox:latest?os=linux&arch=arm64&variant=v8" \
+    tar://busybox-arm64.tar
+```
+
+### Download Multiple Architectures
+
+```bash
+# AMD64
+occystrap process registry://docker.io/library/python:3.11 \
+    tar://python-amd64.tar
+
+# ARM64
+occystrap --architecture arm64 --variant v8 \
+    process registry://docker.io/library/python:3.11 \
+    tar://python-arm64.tar
+```
+
+## Storage Optimization
+
+Reduce disk usage when working with multiple images.
+
+### Shared Layer Storage
+
+```bash
+# Download multiple images with layer deduplication
+occystrap process registry://docker.io/library/python:3.11 \
+    "dir://shared-images?unique_names=true"
+
+occystrap process registry://docker.io/library/python:3.10 \
+    "dir://shared-images?unique_names=true"
+
+occystrap process registry://docker.io/library/python:3.9 \
+    "dir://shared-images?unique_names=true"
+
+# Shared base layers are stored only once
+ls -la shared-images/
+cat shared-images/catalog.json
+```
+
+### Clean Up Images
+
+```bash
+# Exclude unnecessary files to reduce size
+occystrap process registry://docker.io/library/python:3.11 \
+    tar://python-clean.tar \
+    -f "exclude:pattern=**/__pycache__/**,**/*.pyc,**/.git/**"
+```
+
+## OCI Runtime Integration
+
+Create runtime bundles for runc.
+
+### Generate OCI Bundle
+
+```bash
+# Create OCI bundle from registry image
+occystrap process registry://docker.io/library/hello-world:latest \
+    oci://hello-bundle
+
+# Run with runc
+cd hello-bundle
+sudo runc run hello-world
+```
+
+### From Local Docker Image
+
+```bash
+# Export and convert to OCI bundle
+occystrap process docker://myapp:v1 oci://myapp-bundle
+
+# Run the bundle
+cd myapp-bundle
+sudo runc run myapp
+```
+
+## Podman Integration
+
+Work with Podman instead of Docker.
+
+### Enable Podman Socket
+
+```bash
+# Start rootless Podman socket
+systemctl --user start podman.socket
+
+# Or rootful
+sudo systemctl start podman.socket
+```
+
+### Fetch from Podman
+
+```bash
+# Rootless Podman
+occystrap process \
+    "docker://myimage:v1?socket=/run/user/$(id -u)/podman/podman.sock" \
+    tar://myimage.tar
+
+# Rootful Podman
+occystrap process \
+    "docker://myimage:v1?socket=/run/podman/podman.sock" \
+    tar://myimage.tar
+```
+
+### Load into Podman
+
+```bash
+# Load tarball into Podman
+occystrap process tar://myimage.tar \
+    "docker://myimage:v1?socket=/run/user/$(id -u)/podman/podman.sock"
+```
+
+## CI/CD Pipelines
+
+Integrate Occy Strap into build pipelines.
+
+### Cache Images for CI
+
+```bash
+#!/bin/bash
+# ci-image-cache.sh - Download images for CI environment
+
+CACHE_DIR="/var/cache/ci-images"
+mkdir -p "$CACHE_DIR"
+
+# Download with normalized timestamps for consistent caching
+for image in python:3.11 node:18 postgres:15; do
+    name=$(echo "$image" | tr ':' '-')
+    if [ ! -f "$CACHE_DIR/$name.tar" ]; then
+        occystrap process "registry://docker.io/library/$image" \
+            "tar://$CACHE_DIR/$name.tar" -f normalize-timestamps
+    fi
+done
+```
+
+### Verify Image Contents
+
+```bash
+#!/bin/bash
+# verify-image.sh - Check image doesn't contain sensitive files
+
+IMAGE="$1"
+SENSITIVE_PATTERNS="*.pem *.key id_rsa* .env* secrets*"
+
+for pattern in $SENSITIVE_PATTERNS; do
+    matches=$(occystrap search --script-friendly \
+        "registry://$IMAGE" "$pattern" 2>/dev/null)
+    if [ -n "$matches" ]; then
+        echo "WARNING: Found sensitive files matching '$pattern':"
+        echo "$matches"
+        exit 1
+    fi
+done
+
+echo "Image passed security check"
+```
+
+## Debugging
+
+Troubleshoot issues with verbose output.
+
+### Enable Debug Logging
+
+```bash
+occystrap --verbose process registry://docker.io/library/busybox:latest \
+    tar://busybox.tar
+```
+
+### Inspect Layer Contents
+
+```bash
+# Extract layers without merging
+occystrap process registry://docker.io/library/python:3.11 dir://python-layers
+
+# Each layer is a separate tarball
+ls python-layers/*.tar
+
+# Inspect a specific layer
+tar -tvf python-layers/<layer-hash>.tar | head -50
+```


### PR DESCRIPTION
Create a docs/ directory with markdown documentation suitable for publishing to the web. The documentation includes:

- index.md: Main hub with overview and navigation
- installation.md: Getting started guide
- command-reference.md: Complete CLI reference
- pipeline.md: Architecture explanation
- use-cases.md: Common scenarios and examples

Also update README.md to reference the new documentation.

Prompt: I'd like to generate a docs/ directory of documentation about occystrap as markdown that can then be published to the web.