### PR TITLE
Add out-of-order layer delivery and ImageElement.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ various output formats.
 
 1. Create a new file in `occystrap/filters/` (e.g., `myfilter.py`)
 2. Subclass `ImageFilter` from `occystrap.filters.base`
-3. Implement `process_image_element(element_type, name, data)`
+3. Implement `process_image_element(element)` taking an `ImageElement`
 4. Export from `occystrap/filters/__init__.py`
 5. Register in `PipelineBuilder.build_filter()` in `occystrap/pipeline.py`
 
@@ -30,18 +30,22 @@ class MyFilter(ImageFilter):
         super().__init__(wrapped_output)
         self.option = option
 
-    def process_image_element(self, element_type, name, data):
-        if element_type == constants.IMAGE_LAYER and data is not None:
+    def process_image_element(self, element):
+        if (element.element_type == constants.IMAGE_LAYER
+                and element.data is not None):
             # Process the layer, return modified data and new name
-            new_data, new_name = self._process_layer(data)
+            new_data, new_name = self._process_layer(element.data)
             try:
                 self._wrapped.process_image_element(
-                    element_type, new_name, new_data)
+                    constants.ImageElement(
+                        element.element_type, new_name,
+                        new_data,
+                        layer_index=element.layer_index))
             finally:
                 # Clean up temporary files
                 pass
         else:
-            self._wrapped.process_image_element(element_type, name, data)
+            self._wrapped.process_image_element(element)
 ```
 
 ### Adding a New Input Source

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,7 +80,9 @@ All input sources inherit from the `ImageInput` abstract base class defined in
 
 - `image` (property) - Returns the image name
 - `tag` (property) - Returns the image tag
-- `fetch(fetch_callback)` - Yields image elements (config files and layers)
+- `fetch(fetch_callback, ordered)` - Yields `ImageElement` objects (config
+  files and layers). When `ordered=False`, layers may arrive out of manifest
+  order with `layer_index` set for reordering at finalize time.
 
 Input source implementations:
 - `inputs/docker.py` - Fetches images from local Docker daemon via Unix socket,
@@ -117,8 +119,11 @@ Filter implementations:
 All output writers inherit from the `ImageOutput` abstract base class defined in
 `outputs/base.py`. This ABC defines the interface:
 
+- `requires_ordered_layers` (property) - Whether layers must arrive in
+  manifest order (default `True`)
 - `fetch_callback(digest)` - Returns whether a layer should be fetched
-- `process_image_element(type, name, data)` - Handles CONFIG_FILE or IMAGE_LAYER
+- `process_image_element(element)` - Handles an `ImageElement` (config or
+  layer)
 - `finalize()` - Writes manifest and completes output
 
 The base class also provides summary statistics tracking. All output writers log
@@ -148,9 +153,26 @@ Output writer implementations:
 
 ### Element Types
 
-Defined in `constants.py`:
+Pipeline elements are represented as `ImageElement` dataclass instances
+(defined in `constants.py`):
+
+```python
+@dataclasses.dataclass
+class ImageElement:
+    element_type: str   # CONFIG_FILE or IMAGE_LAYER
+    name: str           # Filename or digest hash
+    data: object        # File-like object or None (skipped)
+    layer_index: int | None = None  # Manifest position
+```
+
+Element types:
 - `CONFIG_FILE` - Image configuration JSON
 - `IMAGE_LAYER` - Tarball containing filesystem layer
+
+The `layer_index` field is set when layers are delivered out of order
+(i.e., when the output's `requires_ordered_layers` is `False`). Outputs
+use this index to reconstruct the correct manifest layer order at
+`finalize()` time.
 
 ## URI-Style Command Line
 
@@ -258,9 +280,12 @@ fetch() generator
     └── If OCI: pre-compute manifest from DiffIDs
     └── If legacy: identify config early from inspect hash
     └── For each file in stream:
-        ├── If next expected layer: yield directly (no disk I/O)
-        └── If out-of-order: buffer to temp file for later
-    └── After stream ends: yield remaining buffered layers in order
+        ├── If ordered=True:
+        │   ├── If next expected layer: yield directly (no disk I/O)
+        │   └── If out-of-order: buffer to temp file for later
+        └── If ordered=False:
+            └── Any known layer: yield immediately with layer_index
+    └── After stream ends: yield remaining buffered layers
 ```
 
 Key design considerations:
@@ -282,7 +307,9 @@ layer downloads:
 fetch() generator
     └── Yield config file first (synchronous)
     └── Submit all layer downloads to ThreadPoolExecutor
-    └── Yield layers in order as downloads complete
+    └── If ordered=True: yield layers in manifest order
+    └── If ordered=False: yield layers as downloads complete
+        (each with layer_index for reordering)
 
 _download_layer() worker
     └── Fetch layer blob from registry
@@ -292,7 +319,10 @@ _download_layer() worker
 
 Key design considerations:
 - All layers are downloaded in parallel to maximize throughput
-- Layers are yielded to the pipeline in order despite parallel download
+- When `ordered=True`, layers are yielded in manifest order despite
+  parallel download
+- When `ordered=False`, layers are yielded as downloads complete via
+  `as_completed()`, with `layer_index` set for manifest reconstruction
 - Authentication token updates are protected by a threading lock
 - The `max_workers` parameter controls parallelism (default: 4)
 - Temp files are cleaned up after each layer is processed
@@ -319,7 +349,8 @@ finalize()
 Key design considerations:
 - Both compression and upload run in the thread pool, allowing multiple layers
   to compress simultaneously on multi-core systems
-- Layer order is preserved by collecting futures in submission order at finalize
+- Layer order is preserved by tracking `layer_index` on each future and
+  sorting at finalize time
 - Progress is reported every 10 seconds during the wait phase
 - Authentication token updates are protected by a threading lock for
   thread-safety
@@ -330,6 +361,37 @@ Key design considerations:
 - Cross-invocation layer cache (`--layer-cache`) skips layers that were
   previously processed with the same filter configuration and whose
   compressed blobs still exist in the target registry
+
+### Out-of-Order Layer Delivery
+
+The pipeline supports out-of-order layer delivery to maximize throughput.
+Outputs declare whether they need layers in manifest order via the
+`requires_ordered_layers` property:
+
+| Output | `requires_ordered_layers` | Reason |
+|--------|---------------------------|--------|
+| `dir` (expand=True) | `True` | Whiteout processing needs order |
+| `oci` | `True` | Inherits from DirWriter with expand |
+| `dir` (expand=False) | `False` | Just writes files |
+| `tar` | `False` | Manifest built at finalize |
+| `docker` | `False` | Manifest built at finalize |
+| `registry` | `False` | Manifest built at finalize |
+| `mounts` | `False` | Just writes files |
+
+When the output declares `requires_ordered_layers = False`:
+1. `_fetch()` in `main.py` passes `ordered=False` to the input's
+   `fetch()` method
+2. The input yields `ImageElement` objects with `layer_index` set to the
+   layer's position in the manifest
+3. The output stores layers with their indices and reconstructs the
+   correct manifest order in `finalize()`
+
+This eliminates unnecessary waiting in the registry input (layers are
+yielded via `as_completed()` instead of waiting for each in sequence)
+and reduces temp file buffering in the Docker input.
+
+Filters propagate `requires_ordered_layers` from their wrapped output,
+so the entire filter chain respects the final output's ordering needs.
 
 ### Cross-Invocation Layer Cache
 
@@ -396,10 +458,22 @@ Media type constants in `constants.py` define Docker and OCI layer types:
 Input URI  -->  Input Source  -->  | Filter Chain    |  -->  Output Writer  -->  Files
                      |              | (optional)      |            |
                    fetch()          +-----------------+        finalize()
+                     |                     |                 (reorder by
+               yields ImageElement  process_image_element()  layer_index)
                      |                     |
                      +---------------------+
-                       process_image_element()
-                              |
                         fetch_callback
                        (skip/include)
+```
+
+The `_fetch()` function in `main.py` connects the pipeline:
+
+```python
+def _fetch(img, output):
+    ordered = output.requires_ordered_layers
+    for element in img.fetch(
+            fetch_callback=output.fetch_callback,
+            ordered=ordered):
+        output.process_image_element(element)
+    output.finalize()
 ```

--- a/deploy/occystrap_ci/tests/test_dir_deep_images.py
+++ b/deploy/occystrap_ci/tests/test_dir_deep_images.py
@@ -23,7 +23,7 @@ class DirDeepImageTestCase(testtools.TestCase):
             img = input_registry.Image(
                 'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
             for image_element in img.fetch(fetch_callback=oci.fetch_callback):
-                oci.process_image_element(*image_element)
+                oci.process_image_element(image_element)
             oci.finalize()
             oci.write_bundle()
 

--- a/deploy/occystrap_ci/tests/test_docker_input.py
+++ b/deploy/occystrap_ci/tests/test_docker_input.py
@@ -695,6 +695,281 @@ class DockerInputTestCase(unittest.TestCase):
         finally:
             os.unlink(tarball_path)
 
+    @mock.patch(
+        'occystrap.inputs.docker'
+        '.requests_unixsocket.Session')
+    def test_fetch_oci_unordered(
+            self, mock_session_class):
+        """Test OCI format with ordered=False.
+
+        Layers should be yielded with layer_index set,
+        allowing outputs to reconstruct manifest order.
+        """
+        config_hex = 'cfgunord1'
+        diff_ids = ['diffaaa', 'diffbbb', 'diffccc']
+
+        tarball_path = self._create_oci_tarball(
+            config_data={
+                'architecture': 'amd64',
+                'os': 'linux'},
+            layers=[
+                {'file1.txt': 'content1'},
+                {'file2.txt': 'content2'},
+                {'file3.txt': 'content3'},
+            ],
+            config_hex=config_hex,
+            diff_ids=diff_ids)
+
+        try:
+            self._make_mock_session(
+                {
+                    'Id': 'sha256:%s' % config_hex,
+                    'RootFS': {
+                        'Type': 'layers',
+                        'Layers': [
+                            'sha256:%s' % d
+                            for d in diff_ids
+                        ]
+                    }
+                },
+                tarball_path,
+                mock_session_class)
+
+            img = input_docker.Image(
+                'myimage', 'v1.0')
+            elements = list(
+                img.fetch(ordered=False))
+
+            # Should yield config + 3 layers
+            self.assertEqual(4, len(elements))
+
+            # Config has no layer_index
+            self.assertEqual(
+                constants.CONFIG_FILE,
+                elements[0].element_type)
+            self.assertIsNone(
+                elements[0].layer_index)
+
+            # Layers have layer_index set
+            layer_elements = [
+                e for e in elements
+                if e.element_type
+                == constants.IMAGE_LAYER]
+            self.assertEqual(3, len(layer_elements))
+
+            # All layers should have data
+            for elem in layer_elements:
+                self.assertIsNotNone(elem.data)
+
+            # Collect indices
+            indices = [
+                e.layer_index
+                for e in layer_elements]
+            # All indices should be set
+            for idx in indices:
+                self.assertIsNotNone(idx)
+            # Should be a permutation of [0, 1, 2]
+            self.assertEqual(
+                sorted(indices), [0, 1, 2])
+
+        finally:
+            os.unlink(tarball_path)
+
+    @mock.patch(
+        'occystrap.inputs.docker'
+        '.requests_unixsocket.Session')
+    def test_fetch_oci_unordered_duplicate_layers(
+            self, mock_session_class):
+        """Test ordered=False with duplicate blob paths.
+
+        Each reference to the same blob must get a
+        unique layer_index.
+        """
+        config_hex = 'cfgdupunord'
+        empty_id = 'emptydup'
+        diff_ids = [
+            'diffa', empty_id, 'diffb', empty_id]
+
+        tarball_path = self._create_oci_tarball(
+            config_data={
+                'architecture': 'amd64',
+                'os': 'linux'},
+            layers=[
+                {'file1.txt': 'content1'},
+                {},
+                {'file3.txt': 'content3'},
+            ],
+            config_hex=config_hex,
+            diff_ids=diff_ids)
+
+        try:
+            self._make_mock_session(
+                {
+                    'Id': 'sha256:%s' % config_hex,
+                    'RootFS': {
+                        'Type': 'layers',
+                        'Layers': [
+                            'sha256:%s' % d
+                            for d in diff_ids
+                        ]
+                    }
+                },
+                tarball_path,
+                mock_session_class)
+
+            img = input_docker.Image(
+                'myimage', 'v1.0')
+            elements = list(
+                img.fetch(ordered=False))
+
+            # Should yield config + 4 layers
+            self.assertEqual(5, len(elements))
+
+            layer_elements = [
+                e for e in elements
+                if e.element_type
+                == constants.IMAGE_LAYER]
+            self.assertEqual(4, len(layer_elements))
+
+            # All layers should have data
+            for elem in layer_elements:
+                self.assertIsNotNone(elem.data)
+
+            # All layer_index values should be unique
+            indices = [
+                e.layer_index
+                for e in layer_elements]
+            self.assertEqual(
+                sorted(indices), [0, 1, 2, 3])
+
+        finally:
+            os.unlink(tarball_path)
+
+    @mock.patch(
+        'occystrap.inputs.docker'
+        '.requests_unixsocket.Session')
+    def test_fetch_oci_unordered_with_callback(
+            self, mock_session_class):
+        """Test ordered=False respects fetch_callback.
+
+        Skipped layers should get layer_index and
+        data=None.
+        """
+        config_hex = 'cfgcbunord'
+        diff_ids = ['diffskip', 'diffkeep']
+
+        tarball_path = self._create_oci_tarball(
+            config_data={
+                'architecture': 'amd64',
+                'os': 'linux'},
+            layers=[
+                {'file1.txt': 'content1'},
+                {'file2.txt': 'content2'},
+            ],
+            config_hex=config_hex,
+            diff_ids=diff_ids)
+
+        try:
+            self._make_mock_session(
+                {
+                    'Id': 'sha256:%s' % config_hex,
+                    'RootFS': {
+                        'Type': 'layers',
+                        'Layers': [
+                            'sha256:%s' % d
+                            for d in diff_ids
+                        ]
+                    }
+                },
+                tarball_path,
+                mock_session_class)
+
+            img = input_docker.Image(
+                'myimage', 'v1.0')
+
+            def skip_first(digest):
+                return digest != 'diffskip'
+
+            elements = list(
+                img.fetch(
+                    fetch_callback=skip_first,
+                    ordered=False))
+
+            self.assertEqual(3, len(elements))
+
+            layer_elements = [
+                e for e in elements
+                if e.element_type
+                == constants.IMAGE_LAYER]
+
+            # Skipped layer has None data and index
+            skipped = [
+                e for e in layer_elements
+                if e.name == 'diffskip'][0]
+            self.assertIsNone(skipped.data)
+            self.assertEqual(0, skipped.layer_index)
+
+            # Kept layer has data and index
+            kept = [
+                e for e in layer_elements
+                if e.name == 'diffkeep'][0]
+            self.assertIsNotNone(kept.data)
+            self.assertEqual(1, kept.layer_index)
+
+        finally:
+            os.unlink(tarball_path)
+
+    @mock.patch(
+        'occystrap.inputs.docker'
+        '.requests_unixsocket.Session')
+    def test_fetch_legacy_unordered(
+            self, mock_session_class):
+        """Test legacy format with ordered=False.
+
+        Legacy format buffers layers until manifest
+        arrives, then yields with layer_index set.
+        """
+        tarball_path = self._create_docker_save_tarball(
+            config_data={
+                'architecture': 'amd64',
+                'os': 'linux'},
+            layers=[
+                ('layer1', {'f1.txt': 'c1'}),
+                ('layer2', {'f2.txt': 'c2'}),
+            ])
+
+        try:
+            self._make_mock_session(
+                {'Id': 'sha256:abc123'},
+                tarball_path,
+                mock_session_class)
+
+            img = input_docker.Image(
+                'myimage', 'v1.0')
+            elements = list(
+                img.fetch(ordered=False))
+
+            # Should yield config + 2 layers
+            self.assertEqual(3, len(elements))
+
+            layer_elements = [
+                e for e in elements
+                if e.element_type
+                == constants.IMAGE_LAYER]
+            self.assertEqual(2, len(layer_elements))
+
+            # Layers should have layer_index set
+            indices = [
+                e.layer_index
+                for e in layer_elements]
+            for idx in indices:
+                self.assertIsNotNone(idx)
+            self.assertEqual(
+                sorted(indices), [0, 1])
+
+        finally:
+            os.unlink(tarball_path)
+
     def test_always_fetch_returns_true(self):
         """Test the always_fetch helper function."""
         self.assertTrue(

--- a/deploy/occystrap_ci/tests/test_docker_input.py
+++ b/deploy/occystrap_ci/tests/test_docker_input.py
@@ -371,19 +371,24 @@ class DockerInputTestCase(unittest.TestCase):
 
             # First element is config
             self.assertEqual(
-                constants.CONFIG_FILE, elements[0][0])
-            self.assertIn('.json', elements[0][1])
+                constants.CONFIG_FILE,
+                elements[0].element_type)
+            self.assertIn('.json', elements[0].name)
 
             # Next two are layers
             self.assertEqual(
-                constants.IMAGE_LAYER, elements[1][0])
-            self.assertEqual('layer1', elements[1][1])
-            self.assertIsNotNone(elements[1][2])
+                constants.IMAGE_LAYER,
+                elements[1].element_type)
+            self.assertEqual(
+                'layer1', elements[1].name)
+            self.assertIsNotNone(elements[1].data)
 
             self.assertEqual(
-                constants.IMAGE_LAYER, elements[2][0])
-            self.assertEqual('layer2', elements[2][1])
-            self.assertIsNotNone(elements[2][2])
+                constants.IMAGE_LAYER,
+                elements[2].element_type)
+            self.assertEqual(
+                'layer2', elements[2].name)
+            self.assertIsNotNone(elements[2].data)
 
         finally:
             os.unlink(tarball_path)
@@ -428,9 +433,11 @@ class DockerInputTestCase(unittest.TestCase):
 
             # Config is first
             self.assertEqual(
-                constants.CONFIG_FILE, elements[0][0])
+                constants.CONFIG_FILE,
+                elements[0].element_type)
             self.assertEqual(
-                '%s.json' % config_hex, elements[0][1])
+                '%s.json' % config_hex,
+                elements[0].name)
 
         finally:
             os.unlink(tarball_path)
@@ -483,21 +490,26 @@ class DockerInputTestCase(unittest.TestCase):
 
             # Config is first
             self.assertEqual(
-                constants.CONFIG_FILE, elements[0][0])
+                constants.CONFIG_FILE,
+                elements[0].element_type)
             self.assertEqual(
                 'blobs/sha256/%s' % config_hex,
-                elements[0][1])
+                elements[0].name)
 
             # Layers in order
             self.assertEqual(
-                constants.IMAGE_LAYER, elements[1][0])
-            self.assertEqual('diff111', elements[1][1])
-            self.assertIsNotNone(elements[1][2])
+                constants.IMAGE_LAYER,
+                elements[1].element_type)
+            self.assertEqual(
+                'diff111', elements[1].name)
+            self.assertIsNotNone(elements[1].data)
 
             self.assertEqual(
-                constants.IMAGE_LAYER, elements[2][0])
-            self.assertEqual('diff222', elements[2][1])
-            self.assertIsNotNone(elements[2][2])
+                constants.IMAGE_LAYER,
+                elements[2].element_type)
+            self.assertEqual(
+                'diff222', elements[2].name)
+            self.assertIsNotNone(elements[2].data)
 
         finally:
             os.unlink(tarball_path)
@@ -535,14 +547,14 @@ class DockerInputTestCase(unittest.TestCase):
             # Layer1 should have None data (skipped)
             layer1_element = [
                 e for e in elements
-                if e[1] == 'layer1'][0]
-            self.assertIsNone(layer1_element[2])
+                if e.name == 'layer1'][0]
+            self.assertIsNone(layer1_element.data)
 
             # Layer2 should have data
             layer2_element = [
                 e for e in elements
-                if e[1] == 'layer2'][0]
-            self.assertIsNotNone(layer2_element[2])
+                if e.name == 'layer2'][0]
+            self.assertIsNotNone(layer2_element.data)
 
         finally:
             os.unlink(tarball_path)
@@ -593,14 +605,14 @@ class DockerInputTestCase(unittest.TestCase):
             # First layer skipped (None data)
             layer1 = [
                 e for e in elements
-                if e[1] == 'diff333'][0]
-            self.assertIsNone(layer1[2])
+                if e.name == 'diff333'][0]
+            self.assertIsNone(layer1.data)
 
             # Second layer has data
             layer2 = [
                 e for e in elements
-                if e[1] == 'diff444'][0]
-            self.assertIsNotNone(layer2[2])
+                if e.name == 'diff444'][0]
+            self.assertIsNotNone(layer2.data)
 
         finally:
             os.unlink(tarball_path)
@@ -657,24 +669,26 @@ class DockerInputTestCase(unittest.TestCase):
 
             # Config is first
             self.assertEqual(
-                constants.CONFIG_FILE, elements[0][0])
+                constants.CONFIG_FILE,
+                elements[0].element_type)
 
             # All 4 layers yielded with data
             layer_elements = [
                 e for e in elements
-                if e[0] == constants.IMAGE_LAYER]
+                if e.element_type
+                == constants.IMAGE_LAYER]
             self.assertEqual(4, len(layer_elements))
 
             # Verify each layer has data
             for elem in layer_elements:
-                self.assertIsNotNone(elem[2])
+                self.assertIsNotNone(elem.data)
 
             # Verify layer order matches DiffIDs
             expected_digests = [
                 'diff555', empty_id,
                 'diff666', empty_id]
             actual_digests = [
-                e[1] for e in layer_elements]
+                e.name for e in layer_elements]
             self.assertEqual(
                 expected_digests, actual_digests)
 

--- a/deploy/occystrap_ci/tests/test_docker_output.py
+++ b/deploy/occystrap_ci/tests/test_docker_output.py
@@ -65,11 +65,14 @@ class DockerWriterTestCase(unittest.TestCase):
             }).encode('utf-8')
 
             writer.process_image_element(
-                constants.CONFIG_FILE,
-                'config.json',
-                io.BytesIO(config_data))
+                constants.ImageElement(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
-            self.assertEqual('config.json', writer._tar_manifest[0]['Config'])
+            self.assertEqual(
+                'config.json',
+                writer._tar_manifest[0]['Config'])
         finally:
             writer._image_tar.close()
             os.unlink(writer._temp_file.name)
@@ -90,9 +93,10 @@ class DockerWriterTestCase(unittest.TestCase):
 
                 with open(layer_tf.name, 'rb') as f:
                     writer.process_image_element(
-                        constants.IMAGE_LAYER,
-                        'sha256_abc123',
-                        f)
+                        constants.ImageElement(
+                            constants.IMAGE_LAYER,
+                            'sha256_abc123',
+                            f))
 
                 self.assertEqual(
                     ['sha256_abc123/layer.tar'],
@@ -126,11 +130,13 @@ class DockerWriterTestCase(unittest.TestCase):
         writer = output_docker.DockerWriter('test/image', 'latest')
 
         # Add config
-        config_data = json.dumps({'architecture': 'amd64'}).encode('utf-8')
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode('utf-8')
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            constants.ImageElement(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         # Add layer
         layer_tf = tempfile.NamedTemporaryFile(delete=False)
@@ -144,9 +150,10 @@ class DockerWriterTestCase(unittest.TestCase):
 
             with open(layer_tf.name, 'rb') as f:
                 writer.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256_abc123',
-                    f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256_abc123',
+                        f))
         finally:
             os.unlink(layer_tf.name)
 
@@ -175,9 +182,10 @@ class DockerWriterTestCase(unittest.TestCase):
         # Add minimal content
         config_data = b'{}'
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            constants.ImageElement(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         with self.assertRaises(Exception) as ctx:
             writer.finalize()
@@ -199,9 +207,10 @@ class DockerWriterTestCase(unittest.TestCase):
 
         config_data = b'{}'
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            constants.ImageElement(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         writer.finalize()
 
@@ -222,9 +231,10 @@ class DockerWriterTestCase(unittest.TestCase):
 
         config_data = b'{}'
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            constants.ImageElement(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         try:
             writer.finalize()

--- a/deploy/occystrap_ci/tests/test_exclude_filter.py
+++ b/deploy/occystrap_ci/tests/test_exclude_filter.py
@@ -212,8 +212,10 @@ class ExcludeFilterTestCase(unittest.TestCase):
                         tw, patterns=['*__pycache__*'])
 
                     exclude_filter.process_image_element(
-                        constants.IMAGE_LAYER, 'originalhash',
-                        open(layer_path, 'rb'))
+                        constants.ImageElement(
+                            constants.IMAGE_LAYER,
+                            'originalhash',
+                            open(layer_path, 'rb')))
 
                     exclude_filter.finalize()
 

--- a/deploy/occystrap_ci/tests/test_filter_chaining.py
+++ b/deploy/occystrap_ci/tests/test_filter_chaining.py
@@ -157,7 +157,9 @@ class FilterChainingTestCase(unittest.TestCase):
                     # Process layer
                     with open(layer_path, 'rb') as f:
                         search_filter.process_image_element(
-                            constants.IMAGE_LAYER, 'originalhash', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'originalhash', f))
 
                     # Search should find .py files (not filtered by exclude)
                     self.assertEqual(1, len(search_filter.results))
@@ -203,13 +205,17 @@ class FilterChainingTestCase(unittest.TestCase):
                         'os': 'linux'
                     }).encode('utf-8')
                     search_filter.process_image_element(
-                        constants.CONFIG_FILE, 'config.json',
-                        io.BytesIO(config_data))
+                        constants.ImageElement(
+                            constants.CONFIG_FILE,
+                            'config.json',
+                            io.BytesIO(config_data)))
 
                     # Process layer
                     with open(layer_path, 'rb') as f:
                         search_filter.process_image_element(
-                            constants.IMAGE_LAYER, 'originalhash', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'originalhash', f))
 
                     search_filter.finalize()
 
@@ -393,7 +399,9 @@ class FilterChainingTestCase(unittest.TestCase):
                     with open(layer_path, 'rb') as f:
                         # Read original for comparison
                         search_filter.process_image_element(
-                            constants.IMAGE_LAYER, original_sha, f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                original_sha, f))
 
                     # Search should find both files
                     self.assertEqual(2, len(search_filter.results))

--- a/deploy/occystrap_ci/tests/test_inspect_filter.py
+++ b/deploy/occystrap_ci/tests/test_inspect_filter.py
@@ -88,18 +88,22 @@ class InspectFilterTestCase(unittest.TestCase):
                 },
             ])
             inspect_filter.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                config_data)
+                constants.ImageElement(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    config_data))
 
             with open(layer_path, 'rb') as f:
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:abc123', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:abc123', f))
 
             with open(layer_path, 'rb') as f:
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:def456', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:def456', f))
 
             inspect_filter.finalize()
 
@@ -151,13 +155,16 @@ class InspectFilterTestCase(unittest.TestCase):
 
                     config_data = self._create_config_data()
                     inspect_filter.process_image_element(
-                        constants.CONFIG_FILE,
-                        'config.json', config_data)
+                        constants.ImageElement(
+                            constants.CONFIG_FILE,
+                            'config.json',
+                            config_data))
 
                     with open(layer_path, 'rb') as f:
                         inspect_filter.process_image_element(
-                            constants.IMAGE_LAYER,
-                            'sha256:abc123', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'sha256:abc123', f))
 
                     inspect_filter.finalize()
 
@@ -195,14 +202,16 @@ class InspectFilterTestCase(unittest.TestCase):
             with open(small_layer, 'rb') as f:
                 small_size = os.fstat(f.fileno()).st_size
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:small', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:small', f))
 
             with open(large_layer, 'rb') as f:
                 large_size = os.fstat(f.fileno()).st_size
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:large', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:large', f))
 
             inspect_filter.finalize()
 
@@ -237,8 +246,9 @@ class InspectFilterTestCase(unittest.TestCase):
                 image='image/one', tag='v1')
             with open(layer_path, 'rb') as f:
                 filter1.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:aaa', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:aaa', f))
             filter1.finalize()
 
             # Second image
@@ -247,8 +257,9 @@ class InspectFilterTestCase(unittest.TestCase):
                 image='image/two', tag='v2')
             with open(layer_path, 'rb') as f:
                 filter2.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:bbb', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:bbb', f))
             filter2.finalize()
 
             with open(output_jsonl.name, 'r') as f:
@@ -305,14 +316,17 @@ class InspectFilterTestCase(unittest.TestCase):
                     # Process config
                     config_data = self._create_config_data()
                     inspect_before.process_image_element(
-                        constants.CONFIG_FILE,
-                        'config.json', config_data)
+                        constants.ImageElement(
+                            constants.CONFIG_FILE,
+                            'config.json',
+                            config_data))
 
                     # Process layer
                     with open(layer_path, 'rb') as f:
                         inspect_before.process_image_element(
-                            constants.IMAGE_LAYER,
-                            'sha256:original', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'sha256:original', f))
 
                     inspect_before.finalize()
 
@@ -395,8 +409,9 @@ class InspectFilterTestCase(unittest.TestCase):
 
                     with open(layer_path, 'rb') as f:
                         inspect_before.process_image_element(
-                            constants.IMAGE_LAYER,
-                            'sha256:original', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'sha256:original', f))
 
                     inspect_before.finalize()
 
@@ -458,19 +473,23 @@ class InspectFilterTestCase(unittest.TestCase):
                 },
             ])
             inspect_filter.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                config_data)
+                constants.ImageElement(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    config_data))
 
             # Two real layers (the ENV is empty_layer)
             with open(layer_path, 'rb') as f:
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:layer1', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:layer1', f))
 
             with open(layer_path, 'rb') as f:
                 inspect_filter.process_image_element(
-                    constants.IMAGE_LAYER,
-                    'sha256:layer2', f)
+                    constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        'sha256:layer2', f))
 
             inspect_filter.finalize()
 
@@ -542,8 +561,9 @@ class InspectFilterTestCase(unittest.TestCase):
 
                     with open(layer_path, 'rb') as f:
                         inspect_built.process_image_element(
-                            constants.IMAGE_LAYER,
-                            'sha256:original', f)
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'sha256:original', f))
 
                     inspect_built.finalize()
 

--- a/deploy/occystrap_ci/tests/test_normalize_timestamps.py
+++ b/deploy/occystrap_ci/tests/test_normalize_timestamps.py
@@ -138,8 +138,10 @@ class NormalizeTimestampsTestCase(unittest.TestCase):
 
                         # Process the layer through the filter
                         normalizer.process_image_element(
-                            constants.IMAGE_LAYER, 'originalhash',
-                            open(layer_tf.name, 'rb'))
+                            constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                'originalhash',
+                                open(layer_tf.name, 'rb')))
 
                         # Finalize
                         normalizer.finalize()

--- a/deploy/occystrap_ci/tests/test_oci_hello_world.py
+++ b/deploy/occystrap_ci/tests/test_oci_hello_world.py
@@ -43,7 +43,7 @@ class OCIHelloWorldTestCase(testtools.TestCase):
             img = input_registry.Image(
                 'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
             for image_element in img.fetch(fetch_callback=oci.fetch_callback):
-                oci.process_image_element(*image_element)
+                oci.process_image_element(image_element)
             oci.finalize()
             oci.write_bundle()
 

--- a/deploy/occystrap_ci/tests/test_registry_push.py
+++ b/deploy/occystrap_ci/tests/test_registry_push.py
@@ -40,7 +40,7 @@ class RegistryPushTestCase(testtools.TestCase):
             secure=False, max_workers=4)
 
         for element in src.fetch(fetch_callback=dst.fetch_callback):
-            dst.process_image_element(*element)
+            dst.process_image_element(element)
         dst.finalize()
 
         # Verify by pulling back
@@ -50,8 +50,10 @@ class RegistryPushTestCase(testtools.TestCase):
 
         # Count layers and verify we got content
         layer_count = 0
-        for element in verify.fetch(fetch_callback=always_fetch):
-            if element[0] == constants.IMAGE_LAYER:
+        for element in verify.fetch(
+                fetch_callback=always_fetch):
+            if element.element_type \
+                    == constants.IMAGE_LAYER:
                 layer_count += 1
         self.assertGreater(layer_count, 0)
 
@@ -71,7 +73,7 @@ class RegistryPushTestCase(testtools.TestCase):
             secure=False, max_workers=1)
 
         for element in src.fetch(fetch_callback=dst_seq.fetch_callback):
-            dst_seq.process_image_element(*element)
+            dst_seq.process_image_element(element)
         dst_seq.finalize()
 
         # Push with parallel (max_workers=4)
@@ -84,7 +86,7 @@ class RegistryPushTestCase(testtools.TestCase):
             secure=False, max_workers=4)
 
         for element in src2.fetch(fetch_callback=dst_par.fetch_callback):
-            dst_par.process_image_element(*element)
+            dst_par.process_image_element(element)
         dst_par.finalize()
 
         # Both should have the same number of layers and identical config
@@ -109,11 +111,15 @@ class RegistryPushTestCase(testtools.TestCase):
             secure=False, max_workers=4)
 
         expected_layer_order = []
-        for element in src.fetch(fetch_callback=dst.fetch_callback):
-            dst.process_image_element(*element)
-            if element[0] == constants.IMAGE_LAYER:
-                # Record layer name/digest as we process them
-                expected_layer_order.append(element[1])
+        for element in src.fetch(
+                fetch_callback=dst.fetch_callback):
+            dst.process_image_element(element)
+            if element.element_type \
+                    == constants.IMAGE_LAYER:
+                # Record layer name/digest as we
+                # process them
+                expected_layer_order.append(
+                    element.name)
         dst.finalize()
 
         # Verify layer order matches
@@ -138,7 +144,7 @@ class RegistryPushTestCase(testtools.TestCase):
             'localhost:5000', dst_image, 'v1',
             secure=False, max_workers=4)
         for element in src1.fetch(fetch_callback=dst1.fetch_callback):
-            dst1.process_image_element(*element)
+            dst1.process_image_element(element)
         dst1.finalize()
 
         first_layer_count = len(dst1._layers)
@@ -151,7 +157,7 @@ class RegistryPushTestCase(testtools.TestCase):
             'localhost:5000', dst_image, 'v2',
             secure=False, max_workers=4)
         for element in src2.fetch(fetch_callback=dst2.fetch_callback):
-            dst2.process_image_element(*element)
+            dst2.process_image_element(element)
         dst2.finalize()
 
         second_layer_count = len(dst2._layers)
@@ -179,17 +185,22 @@ class RegistryPushTestCase(testtools.TestCase):
             'localhost:5000', dst_image, tag,
             secure=False, max_workers=4)
 
-        for element in src.fetch(fetch_callback=dst.fetch_callback):
-            element_type, name, data = element
-            if element_type == constants.CONFIG_FILE and data:
-                data.seek(0)
-                original_config = data.read()
-                data.seek(0)
-            elif element_type == constants.IMAGE_LAYER and data:
-                data.seek(0)
-                original_layer_sizes.append(len(data.read()))
-                data.seek(0)
-            dst.process_image_element(*element)
+        for element in src.fetch(
+                fetch_callback=dst.fetch_callback):
+            if (element.element_type
+                    == constants.CONFIG_FILE
+                    and element.data):
+                element.data.seek(0)
+                original_config = element.data.read()
+                element.data.seek(0)
+            elif (element.element_type
+                    == constants.IMAGE_LAYER
+                    and element.data):
+                element.data.seek(0)
+                original_layer_sizes.append(
+                    len(element.data.read()))
+                element.data.seek(0)
+            dst.process_image_element(element)
         dst.finalize()
 
         # Pull back and verify
@@ -200,12 +211,16 @@ class RegistryPushTestCase(testtools.TestCase):
         verified_config = None
         verified_layer_count = 0
 
-        for element in verify.fetch(fetch_callback=always_fetch):
-            element_type, name, data = element
-            if element_type == constants.CONFIG_FILE and data:
-                data.seek(0)
-                verified_config = data.read()
-            elif element_type == constants.IMAGE_LAYER and data:
+        for element in verify.fetch(
+                fetch_callback=always_fetch):
+            if (element.element_type
+                    == constants.CONFIG_FILE
+                    and element.data):
+                element.data.seek(0)
+                verified_config = element.data.read()
+            elif (element.element_type
+                    == constants.IMAGE_LAYER
+                    and element.data):
                 verified_layer_count += 1
 
         # Config content should be identical

--- a/deploy/occystrap_ci/tests/test_search_layers.py
+++ b/deploy/occystrap_ci/tests/test_search_layers.py
@@ -24,7 +24,7 @@ class SearchLayersTestCase(testtools.TestCase):
         img = input_registry.Image(
             'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
         for image_element in img.fetch(fetch_callback=searcher.fetch_callback):
-            searcher.process_image_element(*image_element)
+            searcher.process_image_element(image_element)
         searcher.finalize()
 
         # busybox should have ash and sh
@@ -43,7 +43,7 @@ class SearchLayersTestCase(testtools.TestCase):
         img = input_registry.Image(
             'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
         for image_element in img.fetch(fetch_callback=searcher.fetch_callback):
-            searcher.process_image_element(*image_element)
+            searcher.process_image_element(image_element)
         searcher.finalize()
 
         self.assertEqual(0, len(searcher.results))
@@ -58,7 +58,7 @@ class SearchLayersTestCase(testtools.TestCase):
         img = input_registry.Image(
             'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
         for image_element in img.fetch(fetch_callback=searcher.fetch_callback):
-            searcher.process_image_element(*image_element)
+            searcher.process_image_element(image_element)
         searcher.finalize()
 
         # Should find ash and sh
@@ -78,7 +78,7 @@ class SearchLayersScriptFriendlyTestCase(testtools.TestCase):
         img = input_registry.Image(
             'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
         for image_element in img.fetch(fetch_callback=searcher.fetch_callback):
-            searcher.process_image_element(*image_element)
+            searcher.process_image_element(image_element)
 
         # Capture stdout during finalize
         old_stdout = sys.stdout
@@ -116,7 +116,7 @@ class SearchLayersScriptFriendlyTestCase(testtools.TestCase):
         img = input_registry.Image(
             'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
         for image_element in img.fetch(fetch_callback=searcher.fetch_callback):
-            searcher.process_image_element(*image_element)
+            searcher.process_image_element(image_element)
 
         # Capture stdout during finalize
         old_stdout = sys.stdout
@@ -144,7 +144,7 @@ class SearchLayersTarfileTestCase(testtools.TestCase):
             img = input_registry.Image(
                 'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
             for image_element in img.fetch(fetch_callback=tar.fetch_callback):
-                tar.process_image_element(*image_element)
+                tar.process_image_element(image_element)
             tar.finalize()
 
             # Now search the tarball
@@ -152,7 +152,7 @@ class SearchLayersTarfileTestCase(testtools.TestCase):
             searcher = SearchFilter(None, '*sh')
             for image_element in tarball_img.fetch(
                     fetch_callback=searcher.fetch_callback):
-                searcher.process_image_element(*image_element)
+                searcher.process_image_element(image_element)
             searcher.finalize()
 
             # Should find shells
@@ -179,7 +179,7 @@ class SearchLayersTarfileTestCase(testtools.TestCase):
             img = input_registry.Image(
                 'localhost:5000', image, tag, 'linux', 'amd64', '', secure=False)
             for image_element in img.fetch(fetch_callback=tar.fetch_callback):
-                tar.process_image_element(*image_element)
+                tar.process_image_element(image_element)
             tar.finalize()
 
             # Now search the tarball with script-friendly output
@@ -189,7 +189,7 @@ class SearchLayersTarfileTestCase(testtools.TestCase):
                 script_friendly=True)
             for image_element in tarball_img.fetch(
                     fetch_callback=searcher.fetch_callback):
-                searcher.process_image_element(*image_element)
+                searcher.process_image_element(image_element)
 
             # Capture stdout during finalize
             old_stdout = sys.stdout

--- a/deploy/occystrap_ci/tests/test_whiteout.py
+++ b/deploy/occystrap_ci/tests/test_whiteout.py
@@ -26,7 +26,7 @@ class WhiteoutsTestCase(testtools.TestCase):
                 'localhost:5000', image, tag, 'linux', 'amd64', '',
                 secure=False)
             for image_element in img.fetch(fetch_callback=oci.fetch_callback):
-                oci.process_image_element(*image_element)
+                oci.process_image_element(image_element)
             oci.finalize()
             oci.write_bundle()
 
@@ -56,7 +56,7 @@ class WhiteoutsTestCase(testtools.TestCase):
                 'localhost:5000', image, tag, 'linux', 'amd64', '',
                 secure=False)
             for image_element in img.fetch(fetch_callback=oci.fetch_callback):
-                oci.process_image_element(*image_element)
+                oci.process_image_element(image_element)
             oci.finalize()
             oci.write_bundle()
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -17,7 +17,17 @@ Input Source  -->  Filter Chain (optional)  -->  Output Writer  -->  Files
 
 ## Image Elements
 
-Container images consist of two types of elements:
+Container images consist of two types of elements, represented as
+`ImageElement` dataclass instances:
+
+```python
+@dataclasses.dataclass
+class ImageElement:
+    element_type: str   # CONFIG_FILE or IMAGE_LAYER
+    name: str           # Filename or digest hash
+    data: object        # File-like object or None (skipped)
+    layer_index: int | None = None  # Manifest position
+```
 
 | Element Type | Description |
 |--------------|-------------|
@@ -25,7 +35,9 @@ Container images consist of two types of elements:
 | `IMAGE_LAYER` | Tarball containing a filesystem layer |
 
 Each element flows through the pipeline independently, allowing streaming
-processing without loading entire images into memory.
+processing without loading entire images into memory. The `layer_index`
+field is set when layers are delivered out of order (see
+[Out-of-Order Delivery](#out-of-order-layer-delivery) below).
 
 ## Input Sources
 
@@ -55,12 +67,16 @@ Layer blobs are downloaded in parallel using a thread pool:
 fetch() generator
     └── Yield config file first (synchronous)
     └── Submit all layer downloads to thread pool
-    └── Yield layers in order as downloads complete
+    └── If ordered=True: yield layers in manifest order
+    └── If ordered=False: yield layers as downloads complete
+        (each with layer_index for reordering)
 ```
 
 Key aspects:
 - All layers download simultaneously to maximize throughput
-- Layers are yielded in order despite parallel download
+- When `ordered=True`, layers are yielded in manifest order
+- When `ordered=False`, layers are yielded via `as_completed()` with
+  `layer_index` set, eliminating unnecessary waiting
 - Authentication is thread-safe
 - Default parallelism is 4 threads, configurable via `--parallel`
 
@@ -124,15 +140,22 @@ class MyFilter(ImageFilter):
     def __init__(self, wrapped_output):
         self.wrapped = wrapped_output
 
-    def process_image_element(self, element_type, name, data):
+    def process_image_element(self, element):
         # Transform the element
-        modified_data = transform(data)
+        modified_data = transform(element.data)
         modified_name = new_name_if_changed
 
-        # Pass to wrapped output
-        self.wrapped.process_image_element(element_type, modified_name,
-                                           modified_data)
+        # Pass to wrapped output with a new ImageElement
+        self.wrapped.process_image_element(
+            constants.ImageElement(
+                element.element_type, modified_name,
+                modified_data,
+                layer_index=element.layer_index))
 ```
+
+Filters propagate the `requires_ordered_layers` property from their
+wrapped output, so the pipeline respects the final output's ordering
+needs.
 
 ### Filter Capabilities
 
@@ -278,7 +301,8 @@ finalize()
 Key design aspects:
 - Multiple layers can compress simultaneously, utilizing multiple CPU cores
 - While one layer is compressing, others can be uploading
-- Layer order is preserved by collecting futures in submission order
+- Layer order is preserved by tracking `layer_index` and sorting at
+  finalize time
 - Authentication token updates are thread-safe
 - Progress is reported every 10 seconds during finalize
 - Default parallelism is 4 threads, configurable via `--parallel` or `-j`,
@@ -404,6 +428,26 @@ and `exclude` to maximize layer deduplication:
 
 This means that if two images share identical layers (after filtering),
 the second push will skip uploading those layers entirely.
+
+### Out-of-Order Layer Delivery
+
+The pipeline supports out-of-order layer delivery to maximize throughput
+when the output doesn't require manifest ordering. Each output declares
+its ordering needs via the `requires_ordered_layers` property:
+
+- **Order-dependent** (`True`): `dir` with `expand=True`, `oci`
+- **Order-independent** (`False`): `registry`, `tar`, `docker`,
+  `dir` (expand=False), `mounts`
+
+When `requires_ordered_layers` is `False`:
+1. The input's `fetch()` receives `ordered=False`
+2. Layers are yielded as they become available with `layer_index` set
+3. The output stores layers with their indices
+4. `finalize()` sorts by index to reconstruct the correct manifest order
+
+This is particularly beneficial for the registry-to-registry pipeline,
+where layers can start uploading as soon as they finish downloading
+rather than waiting for earlier layers to complete first.
 
 ### Hash Recalculation
 

--- a/occystrap/constants.py
+++ b/occystrap/constants.py
@@ -1,5 +1,31 @@
+import dataclasses
+
+
 CONFIG_FILE = 'config_file'
 IMAGE_LAYER = 'image_layer'
+
+
+@dataclasses.dataclass
+class ImageElement:
+    """A single element (config or layer) flowing through
+    the pipeline.
+
+    Attributes:
+        element_type: CONFIG_FILE or IMAGE_LAYER.
+        name: Config filename or layer digest.
+        data: File-like object, or None if the layer was
+            skipped by fetch_callback.
+        layer_index: The layer's position in the manifest
+            (0-based). Set by inputs when the output does
+            not require ordered delivery. None for config
+            elements or when ordering is preserved.
+    """
+
+    element_type: str
+    name: str
+    data: object
+    layer_index: int | None = None
+
 
 # Compression type constants
 COMPRESSION_GZIP = 'gzip'

--- a/occystrap/filters/base.py
+++ b/occystrap/filters/base.py
@@ -6,65 +6,89 @@ from occystrap.outputs.base import ImageOutput
 class ImageFilter(ImageOutput, ABC):
     """Abstract base class for image filters.
 
-    Filters wrap an ImageOutput and can transform or inspect image elements
-    as they pass through the pipeline. Filters implement the ImageOutput
-    interface so they can be chained together or used as the final output.
+    Filters wrap an ImageOutput and can transform or
+    inspect image elements as they pass through the
+    pipeline. Filters implement the ImageOutput
+    interface so they can be chained together or used
+    as the final output.
 
     The decorator pattern allows filters to be stacked:
         input -> filter1 -> filter2 -> output
 
     Each filter can:
-    - Transform element data (e.g., normalize timestamps)
-    - Transform element names (e.g., recalculate hashes)
-    - Inspect elements without modification (e.g., search)
+    - Transform element data (e.g., normalize
+      timestamps)
+    - Transform element names (e.g., recalculate
+      hashes)
+    - Inspect elements without modification (e.g.,
+      search)
     - Skip elements entirely
-    - Accumulate state across elements (e.g., collect search results)
+    - Accumulate state across elements (e.g., collect
+      search results)
     """
 
     def __init__(self, wrapped_output, temp_dir=None):
-        """Wrap another output (or filter) to form a chain.
+        """Wrap another output (or filter) to form a
+        chain.
 
         Args:
-            wrapped_output: The ImageOutput to pass processed elements to.
-                Can be None for terminal filters that don't produce output
-                (e.g., search-only mode).
-            temp_dir: Directory for temporary files (default:
-                system temp directory).
+            wrapped_output: The ImageOutput to pass
+                processed elements to. Can be None for
+                terminal filters that don't produce
+                output (e.g., search-only mode).
+            temp_dir: Directory for temporary files
+                (default: system temp directory).
         """
         self._wrapped = wrapped_output
         self.temp_dir = temp_dir
 
+    @property
+    def requires_ordered_layers(self):
+        """Delegate ordering requirement to the wrapped
+        output.
+
+        If there is no wrapped output, default to
+        requiring ordered delivery.
+        """
+        if self._wrapped is None:
+            return True
+        return self._wrapped.requires_ordered_layers
+
     def fetch_callback(self, digest):
         """Determine whether a layer should be fetched.
 
-        Default implementation delegates to the wrapped output.
-        Override to implement custom filtering logic.
+        Default implementation delegates to the wrapped
+        output. Override to implement custom filtering
+        logic.
         """
         if self._wrapped is None:
             return True
         return self._wrapped.fetch_callback(digest)
 
     @abstractmethod
-    def process_image_element(self, element_type, name, data):
-        """Process and optionally transform an image element.
+    def process_image_element(self, element):
+        """Process and optionally transform an image
+        element.
 
         Implementations should typically:
         1. Perform any transformation or inspection
-        2. Pass the (possibly modified) element to self._wrapped
+        2. Pass the (possibly modified) element to
+           self._wrapped
+
+        When creating a modified element, preserve
+        layer_index from the original element.
 
         Args:
-            element_type: constants.CONFIG_FILE or constants.IMAGE_LAYER
-            name: The element name/digest
-            data: File-like object containing the element data, or None
-                if the element was skipped by fetch_callback
+            element: An ImageElement instance.
         """
         pass
 
     def finalize(self):
         """Complete the filter operation.
 
-        Default implementation delegates to the wrapped output.
-        Override to perform cleanup or output accumulated results.
+        Default implementation delegates to the wrapped
+        output. Override to perform cleanup or output
+        accumulated results.
         """
         if self._wrapped is not None:
             self._wrapped.finalize()

--- a/occystrap/filters/exclude.py
+++ b/occystrap/filters/exclude.py
@@ -115,20 +115,27 @@ class ExcludeFilter(ImageFilter):
                 os.unlink(filtered_tf.name)
                 raise
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, filtering layer contents.
+    def process_image_element(self, element):
+        """Process an image element, filtering layer
+        contents.
 
-        Config files are passed through unchanged. Layers have matching
-        entries excluded and their names updated to reflect the new
-        SHA256 hash.
+        Config files are passed through unchanged. Layers
+        have matching entries excluded and their names
+        updated to reflect the new SHA256 hash.
         """
-        if element_type == constants.IMAGE_LAYER and data is not None:
-            LOG.info('Filtering layer %s' % name)
-            filtered_data, new_name = self._filter_layer(data)
+        if (element.element_type == constants.IMAGE_LAYER
+                and element.data is not None):
+            LOG.info('Filtering layer %s' % element.name)
+            filtered_data, new_name = \
+                self._filter_layer(element.data)
 
             try:
                 self._wrapped.process_image_element(
-                    element_type, new_name, filtered_data)
+                    constants.ImageElement(
+                        element.element_type,
+                        new_name,
+                        filtered_data,
+                        layer_index=element.layer_index))
             finally:
                 try:
                     filtered_data.close()
@@ -136,4 +143,4 @@ class ExcludeFilter(ImageFilter):
                 except Exception:
                     pass
         else:
-            self._wrapped.process_image_element(element_type, name, data)
+            self._wrapped.process_image_element(element)

--- a/occystrap/filters/inspect.py
+++ b/occystrap/filters/inspect.py
@@ -79,26 +79,27 @@ class InspectFilter(ImageFilter):
             return 'sha256:%s' % name
         return name
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, recording layer metadata."""
-        if element_type == constants.CONFIG_FILE and data is not None:
-            self._parse_config(data)
+    def process_image_element(self, element):
+        """Process an image element, recording layer
+        metadata."""
+        if (element.element_type == constants.CONFIG_FILE
+                and element.data is not None):
+            self._parse_config(element.data)
 
-        if element_type == constants.IMAGE_LAYER:
-            if data is not None:
-                data.seek(0, 2)
-                size = data.tell()
-                data.seek(0)
+        if element.element_type == constants.IMAGE_LAYER:
+            if element.data is not None:
+                element.data.seek(0, 2)
+                size = element.data.tell()
+                element.data.seek(0)
             else:
                 size = 0
-            self._layers.append((name, size))
+            self._layers.append((element.name, size))
 
         # Pass through to wrapped output
         if self._wrapped is not None:
-            if data is not None:
-                data.seek(0)
-            self._wrapped.process_image_element(
-                element_type, name, data)
+            if element.data is not None:
+                element.data.seek(0)
+            self._wrapped.process_image_element(element)
 
     def _build_layer_entries(self):
         """Build layer entry dicts by correlating layers with

--- a/occystrap/filters/normalize_timestamps.py
+++ b/occystrap/filters/normalize_timestamps.py
@@ -102,27 +102,34 @@ class TimestampNormalizer(ImageFilter):
                 os.unlink(normalized_tf.name)
                 raise
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, normalizing layer timestamps.
+    def process_image_element(self, element):
+        """Process an image element, normalizing layer
+        timestamps.
 
-        Config files are passed through unchanged. Layers have their
-        timestamps normalized and their names updated to reflect the
-        new SHA256 hash.
+        Config files are passed through unchanged. Layers
+        have their timestamps normalized and their names
+        updated to reflect the new SHA256 hash.
         """
-        if element_type == constants.IMAGE_LAYER and data is not None:
-            LOG.info('Normalizing timestamps in layer %s' % name)
-            normalized_data, new_name = self._normalize_layer(data)
+        if (element.element_type == constants.IMAGE_LAYER
+                and element.data is not None):
+            LOG.info(
+                'Normalizing timestamps in layer %s'
+                % element.name)
+            normalized_data, new_name = \
+                self._normalize_layer(element.data)
 
             try:
                 self._wrapped.process_image_element(
-                    element_type, new_name, normalized_data)
+                    constants.ImageElement(
+                        element.element_type,
+                        new_name,
+                        normalized_data,
+                        layer_index=element.layer_index))
             finally:
-                # Clean up the temporary file
                 try:
                     normalized_data.close()
                     os.unlink(normalized_data.name)
                 except Exception:
                     pass
         else:
-            # Pass through unchanged (config files, skipped layers)
-            self._wrapped.process_image_element(element_type, name, data)
+            self._wrapped.process_image_element(element)

--- a/occystrap/filters/search.py
+++ b/occystrap/filters/search.py
@@ -113,17 +113,19 @@ class SearchFilter(ImageFilter):
         except tarfile.TarError as e:
             LOG.error('Failed to read layer %s: %s' % (name, e))
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, searching layers for matches."""
+    def process_image_element(self, element):
+        """Process an image element, searching layers
+        for matches."""
         # Search layers
-        if element_type == constants.IMAGE_LAYER and data is not None:
-            self._search_layer(name, data)
+        if (element.element_type == constants.IMAGE_LAYER
+                and element.data is not None):
+            self._search_layer(element.name, element.data)
 
         # Pass through to wrapped output if present
         if self._wrapped is not None:
-            if data is not None:
-                data.seek(0)  # Reset for next consumer
-            self._wrapped.process_image_element(element_type, name, data)
+            if element.data is not None:
+                element.data.seek(0)
+            self._wrapped.process_image_element(element)
 
     def _print_results(self):
         """Print search results to stdout."""

--- a/occystrap/inputs/base.py
+++ b/occystrap/inputs/base.py
@@ -4,9 +4,9 @@ from abc import ABC, abstractmethod
 class ImageInput(ABC):
     """Abstract base class for image input sources.
 
-    Input sources are responsible for fetching container images from various
-    sources (registries, local Docker daemon, tarfiles) and yielding image
-    elements (config files and layers) in a standard format.
+    Input sources are responsible for fetching container
+    images from various sources (registries, local Docker
+    daemon, tarfiles) and yielding ImageElement objects.
     """
 
     @property
@@ -22,19 +22,20 @@ class ImageInput(ABC):
         pass
 
     @abstractmethod
-    def fetch(self, fetch_callback=None):
+    def fetch(self, fetch_callback=None, ordered=True):
         """Fetch image elements (config files and layers).
 
         Args:
-            fetch_callback: Optional callable that takes a layer digest and
-                returns True if the layer should be fetched, False to skip.
+            fetch_callback: Optional callable that takes
+                a layer digest and returns True if the
+                layer should be fetched, False to skip.
                 If None, all layers are fetched.
+            ordered: If True, yield layers in manifest
+                order (default). If False, yield layers
+                as they become available and set
+                layer_index on each ImageElement.
 
         Yields:
-            Tuples of (element_type, name, data) where:
-            - element_type is constants.CONFIG_FILE or constants.IMAGE_LAYER
-            - name is the element identifier (config filename or layer digest)
-            - data is a file-like object containing the element data,
-              or None if the layer was skipped by fetch_callback
+            ImageElement instances.
         """
         pass

--- a/occystrap/inputs/docker.py
+++ b/occystrap/inputs/docker.py
@@ -224,17 +224,22 @@ class Image(ImageInput):
         except OSError:
             pass
 
-    def fetch(self, fetch_callback=always_fetch):
-        """Fetch image layers from the local Docker daemon.
+    def fetch(self, fetch_callback=always_fetch,
+              ordered=True):
+        """Fetch image layers from the local Docker
+        daemon.
 
-        Uses the inspect API to pre-compute the manifest for
-        Docker 25+ (OCI format), eliminating the need to wait
-        for manifest.json. For older formats (1.10-24.x), the
-        config file is identified early from inspect data.
+        Uses the inspect API to pre-compute the manifest
+        for Docker 25+ (OCI format), eliminating the need
+        to wait for manifest.json. For older formats
+        (1.10-24.x), the config file is identified early
+        from inspect data.
 
-        Uses hybrid streaming: processes layers directly when
-        they arrive in expected order, buffers out-of-order
-        layers to temp files. This minimizes disk usage.
+        Uses hybrid streaming: processes layers directly
+        when they arrive in expected order, buffers
+        out-of-order layers to temp files. When
+        ordered=False, yields layers immediately as they
+        arrive with layer_index set.
         """
         ref = self._get_image_reference()
         LOG.info('Fetching image %s from Docker daemon at %s'
@@ -374,8 +379,20 @@ class Image(ImageInput):
             layer_refcounts[layer_path] = remaining
             return remaining <= 0
 
-        def _yield_layer(layer_path, from_buffer=False):
-            """Yield a layer from a buffered temp file."""
+        def _layer_index_for(layer_path):
+            """Get layer_index for unordered mode."""
+            if ordered or not expected_layers:
+                return None
+            try:
+                return expected_layers.index(
+                    layer_path)
+            except ValueError:
+                return None
+
+        def _yield_layer(layer_path,
+                         from_buffer=False):
+            """Yield a layer from a buffered temp
+            file."""
             layer_digest = self._digest_from_path(
                 layer_path)
             last_ref = _consume_ref(layer_path)
@@ -384,15 +401,19 @@ class Image(ImageInput):
                 buffered.pop(layer_path)
             fh = open(path, 'rb')
             size = os.path.getsize(path)
-            source = 'buffer' if from_buffer else 'temp'
+            source = ('buffer' if from_buffer
+                      else 'temp')
             LOG.info(
                 '%s Yielding layer %s from %s'
                 ' (%d bytes)'
                 % (_layer_progress(), layer_digest,
                    source, size))
             try:
-                yield (constants.IMAGE_LAYER,
-                       layer_digest, fh)
+                yield constants.ImageElement(
+                    constants.IMAGE_LAYER,
+                    layer_digest, fh,
+                    layer_index=_layer_index_for(
+                        layer_path))
             finally:
                 fh.close()
                 if last_ref:
@@ -407,22 +428,29 @@ class Image(ImageInput):
             while (expected_layers
                    and next_layer_idx
                    < len(expected_layers)
-                   and expected_layers[next_layer_idx]
+                   and expected_layers[
+                       next_layer_idx]
                    in buffered):
                 layer_path = \
                     expected_layers[next_layer_idx]
-                layer_digest = self._digest_from_path(
-                    layer_path)
+                layer_digest = \
+                    self._digest_from_path(
+                        layer_path)
 
-                if not fetch_callback(layer_digest):
+                if not fetch_callback(
+                        layer_digest):
                     _consume_ref(layer_path)
                     LOG.info(
                         '%s Skipping layer %s'
                         ' (fetch callback)'
                         % (_layer_progress(),
                            layer_digest))
-                    yield (constants.IMAGE_LAYER,
-                           layer_digest, None)
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        layer_digest, None,
+                        layer_index=(
+                            _layer_index_for(
+                                layer_path)))
                 else:
                     for elem in _yield_layer(
                             layer_path,
@@ -526,7 +554,7 @@ class Image(ImageInput):
                                 config_filename)
                         config_data = fh.read()
                         self._cleanup_file(fh, path)
-                        yield (
+                        yield constants.ImageElement(
                             constants.CONFIG_FILE,
                             config_filename,
                             io.BytesIO(config_data))
@@ -552,7 +580,7 @@ class Image(ImageInput):
                             ' (%d bytes)'
                             % (config_filename,
                                len(config_data)))
-                        yield (
+                        yield constants.ImageElement(
                             constants.CONFIG_FILE,
                             config_filename,
                             io.BytesIO(config_data))
@@ -579,28 +607,37 @@ class Image(ImageInput):
                         ' (%d bytes)'
                         % (config_filename,
                            len(config_data)))
-                    yield (constants.CONFIG_FILE,
-                           config_filename,
-                           io.BytesIO(config_data))
+                    yield constants.ImageElement(
+                        constants.CONFIG_FILE,
+                        config_filename,
+                        io.BytesIO(config_data))
                     config_yielded = True
 
                     for elem in flush_ready_layers():
                         yield elem
                     continue
 
-                # --- Next expected layer ---
+                # --- Known layer (any order) ---
                 if (config_yielded
-                        and next_layer_idx
-                        < len(expected_layers)
+                        and expected_layers
                         and member.name
-                        == expected_layers[
-                            next_layer_idx]):
+                        in expected_layers):
                     layer_path = member.name
                     layer_digest = \
                         self._digest_from_path(
                             layer_path)
+                    idx = _layer_index_for(
+                        layer_path)
 
-                    if not fetch_callback(
+                    # In ordered mode, only handle
+                    # the next expected layer here;
+                    # out-of-order layers fall through
+                    # to the buffering section below.
+                    if ordered and member.name \
+                            != expected_layers[
+                                next_layer_idx]:
+                        pass  # fall through
+                    elif not fetch_callback(
                             layer_digest):
                         _consume_ref(layer_path)
                         LOG.info(
@@ -608,8 +645,16 @@ class Image(ImageInput):
                             ' (fetch callback)'
                             % (_layer_progress(),
                                layer_digest))
-                        yield (constants.IMAGE_LAYER,
-                               layer_digest, None)
+                        yield constants.ImageElement(
+                            constants.IMAGE_LAYER,
+                            layer_digest, None,
+                            layer_index=idx)
+                        if ordered:
+                            next_layer_idx += 1
+                            for elem in \
+                                    flush_ready_layers():
+                                yield elem
+                        continue
                     else:
                         # Buffer to temp file using
                         # chunked I/O, then yield
@@ -628,9 +673,11 @@ class Image(ImageInput):
                             % (_layer_progress(),
                                layer_digest, size))
                         try:
-                            yield (
-                                constants.IMAGE_LAYER,
-                                layer_digest, fh)
+                            yield \
+                                constants.ImageElement(
+                                    constants.IMAGE_LAYER,
+                                    layer_digest, fh,
+                                    layer_index=idx)
                         finally:
                             fh.close()
                             if last_ref:
@@ -645,11 +692,12 @@ class Image(ImageInput):
                                     layer_path
                                 ] = temp_path
                         layers_streamed += 1
-                    next_layer_idx += 1
-
-                    for elem in flush_ready_layers():
-                        yield elem
-                    continue
+                        if ordered:
+                            next_layer_idx += 1
+                            for elem in \
+                                    flush_ready_layers():
+                                yield elem
+                        continue
 
                 # --- Out-of-order or unknown file ---
                 if member.isfile():
@@ -675,12 +723,13 @@ class Image(ImageInput):
                     buffered, config_filename)
                 config_data = fh.read()
                 self._cleanup_file(fh, path)
-                yield (constants.CONFIG_FILE,
-                       config_filename,
-                       io.BytesIO(config_data))
+                yield constants.ImageElement(
+                    constants.CONFIG_FILE,
+                    config_filename,
+                    io.BytesIO(config_data))
                 config_yielded = True
 
-            # Yield remaining buffered layers in order
+            # Yield remaining buffered layers
             if expected_layers \
                     and next_layer_idx \
                     < len(expected_layers):
@@ -688,8 +737,8 @@ class Image(ImageInput):
                     len(expected_layers)
                     - next_layer_idx)
                 LOG.info(
-                    '%d layer(s) remaining in buffer,'
-                    ' yielding in order' % remaining)
+                    '%d layer(s) remaining in'
+                    ' buffer' % remaining)
 
             while expected_layers \
                     and next_layer_idx \
@@ -697,22 +746,28 @@ class Image(ImageInput):
                 layer_path = \
                     expected_layers[next_layer_idx]
                 layer_digest = \
-                    self._digest_from_path(layer_path)
+                    self._digest_from_path(
+                        layer_path)
 
                 if layer_path not in buffered:
                     raise Exception(
                         'Layer %s not found in'
                         ' tarball' % layer_path)
 
-                if not fetch_callback(layer_digest):
+                if not fetch_callback(
+                        layer_digest):
                     _consume_ref(layer_path)
                     LOG.info(
                         '%s Skipping layer %s'
                         ' (fetch callback)'
                         % (_layer_progress(),
                            layer_digest))
-                    yield (constants.IMAGE_LAYER,
-                           layer_digest, None)
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        layer_digest, None,
+                        layer_index=(
+                            _layer_index_for(
+                                layer_path)))
                 else:
                     for elem in _yield_layer(
                             layer_path,

--- a/occystrap/inputs/docker.py
+++ b/occystrap/inputs/docker.py
@@ -276,6 +276,7 @@ class Image(ImageInput):
         format_detected = False
         next_layer_idx = 0
         config_yielded = False
+        yielded_indices = set()
 
         # Reference counts for layer paths. When the same
         # blob path appears multiple times in the manifest
@@ -283,6 +284,14 @@ class Image(ImageInput):
         # must keep the temp file alive until all references
         # are consumed.
         layer_refcounts = {}
+
+        # Per-path index queues for duplicate blob paths.
+        # When the same blob appears multiple times in the
+        # manifest (e.g. ['blobA', 'blobB', 'blobA']),
+        # each reference must get a unique layer_index.
+        # expected_layers.index() always returns the first
+        # occurrence, so we use a queue per path instead.
+        layer_index_queues = {}
 
         # Stats for summary
         layers_streamed = 0
@@ -292,20 +301,28 @@ class Image(ImageInput):
         buffered = {}
 
         def _compute_refcounts():
-            """Compute reference counts for layer paths.
+            """Compute reference counts and index queues.
 
             Some manifests reference the same blob path
             multiple times (e.g., empty layers from
             ENV/CMD). We track how many references
             remain so temp files are kept alive until
             the last reference is consumed.
+
+            Also builds per-path index queues so that
+            duplicate blob paths get unique layer_index
+            values in unordered mode.
             """
-            nonlocal layer_refcounts
+            nonlocal layer_refcounts, layer_index_queues
             layer_refcounts = {}
+            layer_index_queues = {}
             if expected_layers:
-                for path in expected_layers:
+                for i, path in enumerate(
+                        expected_layers):
                     layer_refcounts[path] = \
                         layer_refcounts.get(path, 0) + 1
+                    layer_index_queues.setdefault(
+                        path, []).append(i)
                 dupes = {
                     k: v for k, v
                     in layer_refcounts.items()
@@ -380,14 +397,18 @@ class Image(ImageInput):
             return remaining <= 0
 
         def _layer_index_for(layer_path):
-            """Get layer_index for unordered mode."""
+            """Get layer_index for unordered mode.
+
+            Uses per-path index queues to handle
+            duplicate blob paths correctly. Each call
+            pops the next index for the given path.
+            """
             if ordered or not expected_layers:
                 return None
-            try:
-                return expected_layers.index(
-                    layer_path)
-            except ValueError:
-                return None
+            q = layer_index_queues.get(layer_path)
+            if q:
+                return q.pop(0)
+            return None
 
         def _yield_layer(layer_path,
                          from_buffer=False):
@@ -654,6 +675,8 @@ class Image(ImageInput):
                             for elem in \
                                     flush_ready_layers():
                                 yield elem
+                        elif idx is not None:
+                            yielded_indices.add(idx)
                         continue
                     else:
                         # Buffer to temp file using
@@ -697,6 +720,8 @@ class Image(ImageInput):
                             for elem in \
                                     flush_ready_layers():
                                 yield elem
+                        elif idx is not None:
+                            yielded_indices.add(idx)
                         continue
 
                 # --- Out-of-order or unknown file ---
@@ -743,6 +768,12 @@ class Image(ImageInput):
             while expected_layers \
                     and next_layer_idx \
                     < len(expected_layers):
+                # Skip layers already yielded during
+                # streaming (unordered mode)
+                if next_layer_idx in yielded_indices:
+                    next_layer_idx += 1
+                    continue
+
                 layer_path = \
                     expected_layers[next_layer_idx]
                 layer_digest = \

--- a/occystrap/inputs/registry.py
+++ b/occystrap/inputs/registry.py
@@ -35,7 +35,7 @@ LOG.setLevel(logging.INFO)
 DELETED_FILE_RE = re.compile(r'.*/\.wh\.(.*)$')
 
 
-def always_fetch():
+def always_fetch(digest):
     return True
 
 

--- a/occystrap/inputs/registry.py
+++ b/occystrap/inputs/registry.py
@@ -200,7 +200,8 @@ class Image(ImageInput):
         # Should not reach here, but just in case
         raise Exception('Layer download failed unexpectedly')
 
-    def fetch(self, fetch_callback=always_fetch):
+    def fetch(self, fetch_callback=always_fetch,
+              ordered=True):
         LOG.info('Fetching manifest')
         moniker = 'https'
         if not self.secure:
@@ -208,7 +209,8 @@ class Image(ImageInput):
 
         r = self.request_url(
             'GET',
-            '%(moniker)s://%(registry)s/v2/%(image)s/manifests/%(tag)s'
+            '%(moniker)s://%(registry)s/v2/%(image)s'
+            '/manifests/%(tag)s'
             % {
                 'moniker': moniker,
                 'registry': self.registry,
@@ -234,22 +236,31 @@ class Image(ImageInput):
                 constants.MEDIA_TYPE_OCI_INDEX]:
             for m in r.json()['manifests']:
                 if 'variant' in m['platform']:
-                    LOG.info('Found manifest for %s on %s %s'
-                             % (m['platform']['os'],
-                                m['platform']['architecture'],
-                                m['platform']['variant']))
+                    LOG.info(
+                        'Found manifest for %s on %s %s'
+                        % (m['platform']['os'],
+                           m['platform']['architecture'],
+                           m['platform']['variant']))
                 else:
-                    LOG.info('Found manifest for %s on %s'
-                             % (m['platform']['os'],
-                                m['platform']['architecture']))
+                    LOG.info(
+                        'Found manifest for %s on %s'
+                        % (m['platform']['os'],
+                           m['platform'][
+                               'architecture']))
 
-                if (m['platform']['os'] == self.os and
-                    m['platform']['architecture'] == self.architecture and
-                        m['platform'].get('variant', '') == self.variant):
+                if (m['platform']['os'] == self.os
+                        and m['platform'][
+                            'architecture']
+                        == self.architecture
+                        and m['platform'].get(
+                            'variant', '')
+                        == self.variant):
                     LOG.info('Fetching matching manifest')
                     r = self.request_url(
                         'GET',
-                        '%(moniker)s://%(registry)s/v2/%(image)s/manifests/%(tag)s'
+                        '%(moniker)s://%(registry)s'
+                        '/v2/%(image)s/manifests'
+                        '/%(tag)s'
                         % {
                             'moniker': moniker,
                             'registry': self.registry,
@@ -257,24 +268,30 @@ class Image(ImageInput):
                             'tag': m['digest']
                         },
                         headers={
-                            'Accept': ('%s, %s' % (
-                                constants.MEDIA_TYPE_DOCKER_MANIFEST_V2,
-                                constants.MEDIA_TYPE_OCI_MANIFEST))
+                            'Accept': (
+                                '%s, %s' % (
+                                    constants.MEDIA_TYPE_DOCKER_MANIFEST_V2,
+                                    constants.MEDIA_TYPE_OCI_MANIFEST))
                         })
                     manifest = r.json()
-                    config_digest = manifest['config']['digest']
+                    config_digest = \
+                        manifest['config']['digest']
 
             if not config_digest:
-                raise Exception('Could not find a matching manifest for this '
-                                'os / architecture / variant')
+                raise Exception(
+                    'Could not find a matching'
+                    ' manifest for this'
+                    ' os / architecture / variant')
         else:
-            raise Exception('Unknown manifest content type %s!' %
-                            r.headers['Content-Type'])
+            raise Exception(
+                'Unknown manifest content type %s!'
+                % r.headers['Content-Type'])
 
         LOG.info('Fetching config file')
         r = self.request_url(
             'GET',
-            '%(moniker)s://%(registry)s/v2/%(image)s/blobs/%(config)s'
+            '%(moniker)s://%(registry)s/v2/%(image)s'
+            '/blobs/%(config)s'
             % {
                 'moniker': moniker,
                 'registry': self.registry,
@@ -285,47 +302,117 @@ class Image(ImageInput):
         h = hashlib.sha256()
         h.update(config)
         if h.hexdigest() != config_digest.split(':')[1]:
-            LOG.error('Hash verification failed for image config blob (%s vs %s)'
-                      % (config_digest.split(':')[1], h.hexdigest()))
+            LOG.error(
+                'Hash verification failed for image'
+                ' config blob (%s vs %s)'
+                % (config_digest.split(':')[1],
+                   h.hexdigest()))
             sys.exit(1)
 
-        config_filename = ('%s.json' % config_digest.split(':')[1])
-        yield (constants.CONFIG_FILE, config_filename,
-               io.BytesIO(config))
+        config_filename = (
+            '%s.json' % config_digest.split(':')[1])
+        yield constants.ImageElement(
+            constants.CONFIG_FILE, config_filename,
+            io.BytesIO(config))
 
-        LOG.info('There are %d image layers' % len(manifest['layers']))
+        LOG.info('There are %d image layers'
+                 % len(manifest['layers']))
 
         # Submit all layer downloads in parallel
-        # Each entry is (layer_filename, future_or_none) where None means skip
+        # Each entry is (layer_idx, layer_filename,
+        # future_or_none) where None means skip
         layer_futures = []
-        for layer in manifest['layers']:
-            layer_filename = layer['digest'].split(':')[1]
+        for layer_idx, layer in enumerate(
+                manifest['layers']):
+            layer_filename = \
+                layer['digest'].split(':')[1]
             if not fetch_callback(layer_filename):
-                LOG.info('Fetch callback says skip layer %s' % layer['digest'])
-                layer_futures.append((layer_filename, None))
+                LOG.info(
+                    'Fetch callback says skip'
+                    ' layer %s' % layer['digest'])
+                layer_futures.append(
+                    (layer_idx, layer_filename, None))
             else:
                 future = self._executor.submit(
-                    self._download_layer, layer, moniker)
-                layer_futures.append((layer_filename, future))
+                    self._download_layer, layer,
+                    moniker)
+                layer_futures.append(
+                    (layer_idx, layer_filename,
+                     future))
 
-        # Yield results in order, waiting for each download to complete
-        for layer_filename, future in layer_futures:
-            if future is None:
-                yield (constants.IMAGE_LAYER, layer_filename, None)
-            else:
-                # Wait for this specific download to complete
+        if not ordered:
+            # Yield layers as they complete for
+            # maximum throughput
+            from concurrent.futures import \
+                as_completed
+            # Build future -> (index, filename) map
+            future_map = {}
+            for layer_idx, layer_filename, future \
+                    in layer_futures:
+                if future is None:
+                    # Skipped layers yield immediately
+                    idx = layer_idx
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        layer_filename, None,
+                        layer_index=idx)
+                else:
+                    future_map[future] = (
+                        layer_idx, layer_filename)
+
+            for future in as_completed(future_map):
+                layer_idx, layer_filename = \
+                    future_map[future]
                 try:
-                    result_filename, temp_file_path = future.result()
+                    result_filename, temp_file_path \
+                        = future.result()
                     try:
-                        with open(temp_file_path, 'rb') as f:
-                            yield (constants.IMAGE_LAYER, result_filename, f)
+                        with open(
+                                temp_file_path,
+                                'rb') as f:
+                            yield \
+                                constants.ImageElement(
+                                    constants.IMAGE_LAYER,
+                                    result_filename, f,
+                                    layer_index=layer_idx
+                                )
                     finally:
                         os.unlink(temp_file_path)
                 except Exception:
-                    # Clean up any remaining futures on error
-                    for _, remaining_future in layer_futures:
-                        if remaining_future is not None:
-                            remaining_future.cancel()
+                    for ft in future_map:
+                        ft.cancel()
                     raise
+        else:
+            # Yield results in order, waiting for
+            # each download to complete
+            for layer_idx, layer_filename, future \
+                    in layer_futures:
+                if future is None:
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        layer_filename, None)
+                else:
+                    try:
+                        result_filename, \
+                            temp_file_path = \
+                            future.result()
+                        try:
+                            with open(
+                                    temp_file_path,
+                                    'rb') as f:
+                                yield \
+                                    constants.ImageElement(
+                                        constants.IMAGE_LAYER,
+                                        result_filename,
+                                        f)
+                        finally:
+                            os.unlink(temp_file_path)
+                    except Exception:
+                        for _, _, remaining_future \
+                                in layer_futures:
+                            if remaining_future \
+                                    is not None:
+                                remaining_future.cancel()
+                        raise
 
         LOG.info('Done')

--- a/occystrap/inputs/tarfile.py
+++ b/occystrap/inputs/tarfile.py
@@ -71,54 +71,90 @@ class Image(ImageInput):
     def tag(self):
         return self._tag
 
-    def fetch(self, fetch_callback=always_fetch):
-        LOG.info('Reading image from tarball %s' % self.tarfile_path)
+    def fetch(self, fetch_callback=always_fetch,
+              ordered=True):
+        LOG.info('Reading image from tarball %s'
+                 % self.tarfile_path)
 
         with tarfile.open(self.tarfile_path, 'r') as tf:
             # Yield config file
-            config_filename = self._manifest[0]['Config']
-            LOG.info('Reading config file %s' % config_filename)
-            config_member = tf.getmember(config_filename)
-            config_file = tf.extractfile(config_member)
+            config_filename = \
+                self._manifest[0]['Config']
+            LOG.info('Reading config file %s'
+                     % config_filename)
+            config_member = tf.getmember(
+                config_filename)
+            config_file = tf.extractfile(
+                config_member)
             config_data = config_file.read()
-            yield (constants.CONFIG_FILE, config_filename,
-                   io.BytesIO(config_data))
+            yield constants.ImageElement(
+                constants.CONFIG_FILE,
+                config_filename,
+                io.BytesIO(config_data))
 
             # Yield each layer
             layers = self._manifest[0]['Layers']
-            LOG.info('There are %d image layers' % len(layers))
+            LOG.info('There are %d image layers'
+                     % len(layers))
 
-            for layer_path in layers:
-                # Layer path format varies by Docker version:
-                # - Traditional (v1.10-v24): "<digest>/layer.tar"
-                # - OCI format (v25+): "blobs/sha256/<digest>"
+            for layer_idx, layer_path in \
+                    enumerate(layers):
+                # Layer path format varies by Docker
+                # version:
+                # - Traditional (v1.10-v24):
+                #   "<digest>/layer.tar"
+                # - OCI format (v25+):
+                #   "blobs/sha256/<digest>"
                 if layer_path.startswith('blobs/'):
-                    # OCI format: extract digest from end of path
-                    layer_digest = os.path.basename(layer_path)
+                    layer_digest = os.path.basename(
+                        layer_path)
                 else:
-                    # Traditional format: extract digest from directory name
-                    layer_digest = os.path.dirname(layer_path)
+                    layer_digest = os.path.dirname(
+                        layer_path)
+
+                idx = (layer_idx
+                       if not ordered else None)
+
                 if not fetch_callback(layer_digest):
-                    LOG.info('Fetch callback says skip layer %s' % layer_digest)
-                    yield (constants.IMAGE_LAYER, layer_digest, None)
+                    LOG.info(
+                        'Fetch callback says skip'
+                        ' layer %s' % layer_digest)
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        layer_digest, None,
+                        layer_index=idx)
                     continue
 
-                LOG.info('Reading layer %s' % layer_path)
-                layer_member = tf.getmember(layer_path)
-                layer_file = tf.extractfile(layer_member)
+                LOG.info('Reading layer %s'
+                         % layer_path)
+                layer_member = tf.getmember(
+                    layer_path)
+                layer_file = tf.extractfile(
+                    layer_member)
                 layer_data = layer_file.read()
 
-                # For OCI format (blobs/ paths), layers may be compressed
+                # For OCI format (blobs/ paths),
+                # layers may be compressed
                 if layer_path.startswith('blobs/'):
-                    compression_type = compression.detect_compression(
-                        layer_data)
-                    if compression_type in (constants.COMPRESSION_GZIP,
-                                            constants.COMPRESSION_ZSTD):
-                        LOG.info('Decompressing %s layer' % compression_type)
-                        layer_data = compression.decompress_data(
-                            layer_data, compression_type)
+                    compression_type = \
+                        compression.detect_compression(
+                            layer_data)
+                    if compression_type in (
+                            constants.COMPRESSION_GZIP,
+                            constants.COMPRESSION_ZSTD
+                    ):
+                        LOG.info(
+                            'Decompressing %s layer'
+                            % compression_type)
+                        layer_data = \
+                            compression.decompress_data(
+                                layer_data,
+                                compression_type)
 
-                yield (constants.IMAGE_LAYER, layer_digest,
-                       io.BytesIO(layer_data))
+                yield constants.ImageElement(
+                    constants.IMAGE_LAYER,
+                    layer_digest,
+                    io.BytesIO(layer_data),
+                    layer_index=idx)
 
         LOG.info('Done')

--- a/occystrap/inputs/tarfile.py
+++ b/occystrap/inputs/tarfile.py
@@ -73,6 +73,10 @@ class Image(ImageInput):
 
     def fetch(self, fetch_callback=always_fetch,
               ordered=True):
+        # Note: ordered=False provides no throughput
+        # benefit here since the tarball is read
+        # sequentially. We still set layer_index so
+        # that outputs can reconstruct manifest order.
         LOG.info('Reading image from tarball %s'
                  % self.tarfile_path)
 

--- a/occystrap/main.py
+++ b/occystrap/main.py
@@ -73,8 +73,11 @@ def cli(ctx, verbose=None, os=None, architecture=None, variant=None,
 
 
 def _fetch(img, output):
-    for image_element in img.fetch(fetch_callback=output.fetch_callback):
-        output.process_image_element(*image_element)
+    ordered = output.requires_ordered_layers
+    for element in img.fetch(
+            fetch_callback=output.fetch_callback,
+            ordered=ordered):
+        output.process_image_element(element)
     output.finalize()
 
 
@@ -300,8 +303,8 @@ def recreate_image(ctx, path, image, tag, tarfile, normalize_timestamps,
     tar = output_tarfile.TarWriter(image, tag, tarfile)
     if normalize_timestamps:
         tar = TimestampNormalizer(tar, timestamp=timestamp)
-    for image_element in d.fetch():
-        tar.process_image_element(*image_element)
+    for element in d.fetch():
+        tar.process_image_element(element)
     tar.finalize()
 
 

--- a/occystrap/outputs/base.py
+++ b/occystrap/outputs/base.py
@@ -10,30 +10,47 @@ LOG.setLevel(logging.INFO)
 class ImageOutput(ABC):
     """Abstract base class for image output writers.
 
-    Output writers receive image elements (config files and layers) from input
-    sources and write them to various destinations (tarballs, directories,
-    OCI bundles, etc.).
+    Output writers receive image elements (config files
+    and layers) from input sources and write them to
+    various destinations (tarballs, directories, OCI
+    bundles, etc.).
     """
 
     def __init__(self, temp_dir=None):
         """Initialize tracking for summary statistics.
 
         Args:
-            temp_dir: Directory for temporary files (default:
-                system temp directory).
+            temp_dir: Directory for temporary files
+                (default: system temp directory).
         """
         self._start_time = None
         self._total_bytes = 0
         self._layer_count = 0
         self.temp_dir = temp_dir
 
+    @property
+    def requires_ordered_layers(self):
+        """Whether this output needs layers in manifest
+        order.
+
+        If False, the input may deliver layers out of
+        order for performance, and will set layer_index
+        on each ImageElement so the output can
+        reconstruct the correct manifest order.
+
+        Default is True for backward compatibility.
+        """
+        return True
+
     def _track_element(self, element_type, size):
         """Track an element for summary statistics.
 
-        Call this from process_image_element() to track bytes and layers.
+        Call this from process_image_element() to track
+        bytes and layers.
 
         Args:
-            element_type: The element type (CONFIG_FILE or IMAGE_LAYER)
+            element_type: The element type
+                (CONFIG_FILE or IMAGE_LAYER)
             size: Size of the element in bytes
         """
         if self._start_time is None:
@@ -48,39 +65,44 @@ class ImageOutput(ABC):
     def _log_summary(self):
         """Log a summary of the processing.
 
-        Call this at the end of finalize() to print the summary line.
+        Call this at the end of finalize() to print
+        the summary line.
         """
         if self._start_time is None:
             return
 
         elapsed = time.time() - self._start_time
-        LOG.info(f'Processed {self._total_bytes} bytes in '
-                 f'{self._layer_count} layers in {elapsed:.1f} seconds')
+        LOG.info(
+            f'Processed {self._total_bytes} bytes in '
+            f'{self._layer_count} layers in '
+            f'{elapsed:.1f} seconds')
 
     @abstractmethod
     def fetch_callback(self, digest):
         """Determine whether a layer should be fetched.
 
-        This is called by input sources before fetching each layer, allowing
-        output writers to skip layers that already exist in the destination.
+        This is called by input sources before fetching
+        each layer, allowing output writers to skip
+        layers that already exist in the destination.
 
         Args:
             digest: The layer digest/identifier.
 
         Returns:
-            True if the layer should be fetched, False to skip.
+            True if the layer should be fetched, False
+            to skip.
         """
         pass
 
     @abstractmethod
-    def process_image_element(self, element_type, name, data):
-        """Process a single image element (config or layer).
+    def process_image_element(self, element):
+        """Process a single image element (config or
+        layer).
 
         Args:
-            element_type: constants.CONFIG_FILE or constants.IMAGE_LAYER
-            name: The element identifier (config filename or layer digest)
-            data: A file-like object containing the element data,
-                or None if the layer was skipped by fetch_callback
+            element: An ImageElement instance containing
+                element_type, name, data, and optionally
+                layer_index.
         """
         pass
 
@@ -88,7 +110,8 @@ class ImageOutput(ABC):
     def finalize(self):
         """Complete the output operation.
 
-        This is called after all image elements have been processed. Use this
-        to write manifests, close files, or perform any final cleanup.
+        This is called after all image elements have
+        been processed. Use this to write manifests,
+        close files, or perform any final cleanup.
         """
         pass

--- a/occystrap/outputs/directory.py
+++ b/occystrap/outputs/directory.py
@@ -96,7 +96,8 @@ TARFILE_TYPE_MAP = {
 
 
 class DirWriter(ImageOutput):
-    def __init__(self, image, tag, image_path, unique_names=False, expand=False):
+    def __init__(self, image, tag, image_path,
+                 unique_names=False, expand=False):
         super().__init__()
 
         self.image = image
@@ -107,13 +108,25 @@ class DirWriter(ImageOutput):
 
         self.tar_manifest = [{
             'Layers': [],
-            'RepoTags': ['%s:%s' % (self.image.split('/')[-1], self.tag)]
+            'RepoTags': [
+                '%s:%s' % (self.image.split('/')[-1],
+                           self.tag)]
         }]
         if self.unique_names:
-            self.tar_manifest[0]['ImageName'] = self.image
+            self.tar_manifest[0]['ImageName'] = \
+                self.image
 
         self.bundle = {}
         os.makedirs(self.image_path, exist_ok=True)
+
+        # For out-of-order layer delivery
+        self._indexed_layers = []
+
+    @property
+    def requires_ordered_layers(self):
+        # expand=True needs ordered layers for
+        # whiteout file handling
+        return self.expand
 
     def _manifest_filename(self):
         if not self.unique_names:
@@ -135,77 +148,121 @@ class DirWriter(ImageOutput):
         LOG.info('Layer file is %s' % layer_file_in_dir)
         return not os.path.exists(layer_file_in_dir)
 
-    def process_image_element(self, element_type, name, data):
-        if element_type == constants.CONFIG_FILE:
-            config_file = os.path.join(self.image_path, name)
+    def process_image_element(self, element):
+        if element.element_type == constants.CONFIG_FILE:
+            config_file = os.path.join(
+                self.image_path, element.name)
             config_dir = os.path.dirname(config_file)
             os.makedirs(config_dir, exist_ok=True)
 
-            config_data = data.read()
+            config_data = element.data.read()
             with open(config_file, 'wb') as f:
                 d = json.loads(config_data)
-                f.write(json.dumps(d, indent=4, sort_keys=True).encode('ascii'))
-            self.tar_manifest[0]['Config'] = name
-            self._track_element(element_type, len(config_data))
+                f.write(json.dumps(
+                    d, indent=4,
+                    sort_keys=True).encode('ascii'))
+            self.tar_manifest[0]['Config'] = element.name
+            self._track_element(
+                element.element_type, len(config_data))
 
-        elif element_type == constants.IMAGE_LAYER:
-            layer_dir = os.path.join(self.image_path, name)
+        elif element.element_type == constants.IMAGE_LAYER:
+            layer_dir = os.path.join(
+                self.image_path, element.name)
             os.makedirs(layer_dir, exist_ok=True)
 
-            layer_file = os.path.join(name, 'layer.tar')
-            self.tar_manifest[0]['Layers'].append(layer_file)
+            layer_file = os.path.join(
+                element.name, 'layer.tar')
 
-            layer_file_in_dir = os.path.join(self.image_path, layer_file)
+            if element.layer_index is not None:
+                self._indexed_layers.append(
+                    (element.layer_index, layer_file))
+            else:
+                self.tar_manifest[0][
+                    'Layers'].append(layer_file)
+
+            layer_file_in_dir = os.path.join(
+                self.image_path, layer_file)
             layer_size = 0
             if os.path.exists(layer_file_in_dir):
-                LOG.info('Skipping layer already in output directory')
-                layer_size = os.path.getsize(layer_file_in_dir)
+                LOG.info(
+                    'Skipping layer already in'
+                    ' output directory')
+                layer_size = os.path.getsize(
+                    layer_file_in_dir)
             else:
                 with open(layer_file_in_dir, 'wb') as f:
-                    d = data.read(102400)
+                    d = element.data.read(102400)
                     while d:
                         layer_size += len(d)
                         f.write(d)
-                        d = data.read(102400)
-            self._track_element(element_type, layer_size)
+                        d = element.data.read(102400)
+            self._track_element(
+                element.element_type, layer_size)
 
             if self.expand:
-                # Build a in-memory map of the layout of the final image bundle
-                with tarfile.open(layer_file_in_dir) as layer:
+                # Build an in-memory map of the layout
+                # of the final image bundle
+                with tarfile.open(
+                        layer_file_in_dir) as layer:
                     for mem in layer.getmembers():
                         path = mem.name
-                        dirname, filename = os.path.split(mem.name)
+                        dirname, filename = \
+                            os.path.split(mem.name)
 
-                        # Some light reading on how this works...
+                        # Some light reading on how this
+                        # works...
                         # https://github.com/opencontainers/image-spec/blob/main/layer.md#opaque-whiteout
                         if filename == '.wh..wh..opq':
-                            # A deleted directory, but only for layers below
-                            # this one.
+                            # A deleted directory, but
+                            # only for layers below this
+                            # one.
                             for ent in self.bundle:
-                                if (ent.startswith(dirname) and
-                                        self.bundle[ent][-1].tarpath != layer_file):
-                                    self.bundle[ent].append(
-                                        BundleDeletedFile(ent, layer_file, mem))
+                                if (
+                                    ent.startswith(dirname)
+                                    and self.bundle[
+                                        ent][-1].tarpath
+                                    != layer_file
+                                ):
+                                    self.bundle[
+                                        ent].append(
+                                        BundleDeletedFile(
+                                            ent,
+                                            layer_file,
+                                            mem))
                             continue
 
                         elif filename.startswith('.wh.'):
-                            # A single deleted element, which might not be a
-                            # file.
-                            path = os.path.join(dirname, filename[4:])
-                            if type(self.bundle[path][-1]) is BundleDirectory:
+                            # A single deleted element,
+                            # which might not be a file.
+                            path = os.path.join(
+                                dirname, filename[4:])
+                            if type(
+                                self.bundle[path][-1]
+                            ) is BundleDirectory:
                                 for ent in self.bundle:
-                                    if ent.startswith(path):
-                                        self.bundle[ent].append(
-                                            BundleDeletedFile(ent, layer_file, mem))
+                                    if ent.startswith(
+                                            path):
+                                        self.bundle[
+                                            ent].append(
+                                            BundleDeletedFile(
+                                                ent,
+                                                layer_file,
+                                                mem))
 
-                            serialized = BundleDeletedFile(
-                                path, layer_file, mem)
+                            serialized = \
+                                BundleDeletedFile(
+                                    path, layer_file,
+                                    mem)
                         else:
-                            serialized = TARFILE_TYPE_MAP[mem.type](
-                                mem.name, layer_file, mem)
+                            serialized = \
+                                TARFILE_TYPE_MAP[
+                                    mem.type](
+                                    mem.name,
+                                    layer_file, mem)
 
                         self.bundle.setdefault(path, [])
-                        self.bundle[path].append(serialized)
+                        self.bundle[path].append(
+                            serialized)
 
     def _log_bundle(self):
         savings = 0
@@ -226,6 +283,14 @@ class DirWriter(ImageOutput):
         LOG.info('Flattening image would save %d bytes' % savings)
 
     def finalize(self):
+        # Reconstruct layer order from indices
+        if self._indexed_layers:
+            self._indexed_layers.sort(
+                key=lambda x: x[0])
+            self.tar_manifest[0]['Layers'] = [
+                name for _, name
+                in self._indexed_layers]
+
         if self.expand:
             self._log_bundle()
 
@@ -317,13 +382,20 @@ class DirReader(object):
         self.manifest_filename = c[self.image][self.tag]
 
     def fetch(self):
-        with open(os.path.join(self.path, self.manifest_filename)) as f:
+        with open(os.path.join(
+                self.path,
+                self.manifest_filename)) as f:
             manifest = json.loads(f.read())
 
         config_filename = manifest[0]['Config']
-        with open(os.path.join(self.path, config_filename), 'rb') as f:
-            yield (constants.CONFIG_FILE, config_filename, f)
+        with open(os.path.join(
+                self.path, config_filename), 'rb') as f:
+            yield constants.ImageElement(
+                constants.CONFIG_FILE,
+                config_filename, f)
 
         for layer in manifest[0]['Layers']:
-            with open(os.path.join(self.path, layer), 'rb') as f:
-                yield (constants.IMAGE_LAYER, layer, f)
+            with open(os.path.join(
+                    self.path, layer), 'rb') as f:
+                yield constants.ImageElement(
+                    constants.IMAGE_LAYER, layer, f)

--- a/occystrap/outputs/docker.py
+++ b/occystrap/outputs/docker.py
@@ -1,18 +1,22 @@
-# Load images into the local Docker or Podman daemon via the Docker Engine API.
-# This communicates over a Unix domain socket (default: /var/run/docker.sock).
+# Load images into the local Docker or Podman daemon
+# via the Docker Engine API. This communicates over a
+# Unix domain socket (default: /var/run/docker.sock).
 #
 # Docker Engine API documentation:
 # https://docs.docker.com/engine/api/
 #
 # Podman compatibility:
-# Podman provides a Docker-compatible API via podman.socket. Use the socket
-# option to point to the Podman socket:
+# Podman provides a Docker-compatible API via
+# podman.socket. Use the socket option to point to
+# the Podman socket:
 # - Rootful: /run/podman/podman.sock
 # - Rootless: /run/user/<uid>/podman/podman.sock
-# See: https://docs.podman.io/en/latest/markdown/podman-system-service.1.html
+# See: https://docs.podman.io/en/latest/markdown/
+#      podman-system-service.1.html
 #
-# The API accepts images in the same format as 'docker load', which is the
-# v1.2 tarball format that outputs/tarfile.py creates.
+# The API accepts images in the same format as
+# 'docker load', which is the v1.2 tarball format
+# that outputs/tarfile.py creates.
 
 import io
 import json
@@ -36,15 +40,18 @@ DEFAULT_SOCKET_PATH = '/var/run/docker.sock'
 class DockerWriter(ImageOutput):
     """Loads images into the local Docker daemon.
 
-    This output writer builds a v1.2 format tarball and loads it into
-    the Docker daemon using the POST /images/load API endpoint. This is
-    equivalent to running 'docker load'.
+    This output writer builds a v1.2 format tarball and
+    loads it into the Docker daemon using the POST
+    /images/load API endpoint. This is equivalent to
+    running 'docker load'.
 
-    Uses USTAR format for the outer tarball which contains only short paths
-    (SHA256 hashes and small filenames), avoiding PAX extended headers.
+    Uses USTAR format for the outer tarball which
+    contains only short paths (SHA256 hashes and small
+    filenames), avoiding PAX extended headers.
     """
 
-    def __init__(self, image, tag, socket_path=DEFAULT_SOCKET_PATH,
+    def __init__(self, image, tag,
+                 socket_path=DEFAULT_SOCKET_PATH,
                  temp_dir=None):
         """Initialize the Docker writer.
 
@@ -53,8 +60,8 @@ class DockerWriter(ImageOutput):
             tag: The image tag.
             socket_path: Path to the Docker socket
                 (default: /var/run/docker.sock).
-            temp_dir: Directory for temporary files (default:
-                system temp directory).
+            temp_dir: Directory for temporary files
+                (default: system temp directory).
         """
         super().__init__(temp_dir=temp_dir)
 
@@ -65,65 +72,102 @@ class DockerWriter(ImageOutput):
 
         self._temp_file = tempfile.NamedTemporaryFile(
             delete=False, dir=self.temp_dir)
-        self._image_tar = tarfile.open(fileobj=self._temp_file, mode='w',
-                                       format=tarfile.USTAR_FORMAT)
+        self._image_tar = tarfile.open(
+            fileobj=self._temp_file, mode='w',
+            format=tarfile.USTAR_FORMAT)
 
         self._tar_manifest = [{
             'Layers': [],
-            'RepoTags': ['%s:%s' % (self.image.split('/')[-1], self.tag)]
+            'RepoTags': [
+                '%s:%s' % (self.image.split('/')[-1],
+                           self.tag)]
         }]
+
+        # For out-of-order layer delivery
+        self._indexed_layers = []
+
+    @property
+    def requires_ordered_layers(self):
+        return False
 
     def _get_session(self):
         if self._session is None:
-            self._session = requests_unixsocket.Session()
+            self._session = \
+                requests_unixsocket.Session()
         return self._session
 
     def _socket_url(self, path):
-        encoded_socket = self.socket_path.replace('/', '%2F')
-        return 'http+unix://%s%s' % (encoded_socket, path)
+        encoded_socket = self.socket_path.replace(
+            '/', '%2F')
+        return 'http+unix://%s%s' % (
+            encoded_socket, path)
 
     def fetch_callback(self, digest):
         """Always fetch all layers."""
         return True
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, adding it to the tarball."""
-        if element_type == constants.CONFIG_FILE:
+    def process_image_element(self, element):
+        """Process an image element, adding it to the
+        tarball."""
+        if element.element_type == constants.CONFIG_FILE:
             LOG.info('Adding config file to tarball')
 
-            ti = tarfile.TarInfo(name)
-            ti.size = len(data.read())
-            data.seek(0)
-            self._image_tar.addfile(ti, data)
-            self._tar_manifest[0]['Config'] = name
-            self._track_element(element_type, ti.size)
+            ti = tarfile.TarInfo(element.name)
+            ti.size = len(element.data.read())
+            element.data.seek(0)
+            self._image_tar.addfile(ti, element.data)
+            self._tar_manifest[0]['Config'] = \
+                element.name
+            self._track_element(
+                element.element_type, ti.size)
 
-        elif element_type == constants.IMAGE_LAYER:
+        elif element.element_type == \
+                constants.IMAGE_LAYER:
             LOG.info('Adding layer to tarball')
 
-            name += '/layer.tar'
-            ti = tarfile.TarInfo(name)
-            data.seek(0, os.SEEK_END)
-            ti.size = data.tell()
-            data.seek(0)
-            self._image_tar.addfile(ti, data)
-            self._tar_manifest[0]['Layers'].append(name)
-            self._track_element(element_type, ti.size)
+            layer_name = element.name + '/layer.tar'
+            ti = tarfile.TarInfo(layer_name)
+            element.data.seek(0, os.SEEK_END)
+            ti.size = element.data.tell()
+            element.data.seek(0)
+            self._image_tar.addfile(ti, element.data)
+            self._track_element(
+                element.element_type, ti.size)
+
+            if element.layer_index is not None:
+                self._indexed_layers.append(
+                    (element.layer_index, layer_name))
+            else:
+                self._tar_manifest[0][
+                    'Layers'].append(layer_name)
 
     def finalize(self):
-        """Write manifest and load the image into Docker."""
+        """Write manifest and load the image into
+        Docker."""
+        # Reconstruct layer order from indices
+        if self._indexed_layers:
+            self._indexed_layers.sort(
+                key=lambda x: x[0])
+            self._tar_manifest[0]['Layers'] = [
+                name for _, name
+                in self._indexed_layers]
+
         LOG.info('Writing manifest to tarball')
-        encoded_manifest = json.dumps(self._tar_manifest).encode('utf-8')
+        encoded_manifest = json.dumps(
+            self._tar_manifest).encode('utf-8')
         ti = tarfile.TarInfo('manifest.json')
         ti.size = len(encoded_manifest)
-        self._image_tar.addfile(ti, io.BytesIO(encoded_manifest))
+        self._image_tar.addfile(
+            ti, io.BytesIO(encoded_manifest))
         self._image_tar.close()
 
         temp_path = self._temp_file.name
         self._temp_file.close()
 
         try:
-            LOG.info('Loading image into Docker daemon at %s' % self.socket_path)
+            LOG.info(
+                'Loading image into Docker daemon'
+                ' at %s' % self.socket_path)
             session = self._get_session()
             url = self._socket_url('/images/load')
 
@@ -131,15 +175,18 @@ class DockerWriter(ImageOutput):
                 r = session.post(
                     url,
                     data=f,
-                    headers={'Content-Type': 'application/x-tar'}
-                )
+                    headers={
+                        'Content-Type':
+                            'application/x-tar'})
 
             if r.status_code != 200:
                 raise Exception(
-                    'Docker API error %d: %s' % (r.status_code, r.text))
+                    'Docker API error %d: %s'
+                    % (r.status_code, r.text))
 
-            LOG.info('Image loaded successfully: %s:%s'
-                     % (self.image, self.tag))
+            LOG.info(
+                'Image loaded successfully: %s:%s'
+                % (self.image, self.tag))
             self._log_summary()
 
         finally:

--- a/occystrap/outputs/mounts.py
+++ b/occystrap/outputs/mounts.py
@@ -24,13 +24,22 @@ class MountWriter(ImageOutput):
 
         self.tar_manifest = [{
             'Layers': [],
-            'RepoTags': ['%s:%s' % (self.image.split('/')[-1], self.tag)]
+            'RepoTags': [
+                '%s:%s' % (self.image.split('/')[-1],
+                           self.tag)]
         }]
 
         self.bundle = {}
 
+        # For out-of-order layer delivery
+        self._indexed_layers = []
+
         if not os.path.exists(self.image_path):
             os.makedirs(self.image_path)
+
+    @property
+    def requires_ordered_layers(self):
+        return False
 
     def _manifest_filename(self):
         return 'manifest'
@@ -40,65 +49,110 @@ class MountWriter(ImageOutput):
         LOG.info('Layer file is %s' % layer_file_in_dir)
         return not os.path.exists(layer_file_in_dir)
 
-    def process_image_element(self, element_type, name, data):
-        if element_type == constants.CONFIG_FILE:
-            config_data = data.read()
-            with open(os.path.join(self.image_path, name), 'wb') as f:
+    def process_image_element(self, element):
+        if element.element_type == constants.CONFIG_FILE:
+            config_data = element.data.read()
+            with open(os.path.join(
+                    self.image_path,
+                    element.name), 'wb') as f:
                 d = json.loads(config_data)
-                f.write(json.dumps(d, indent=4, sort_keys=True).encode('ascii'))
-            self.tar_manifest[0]['Config'] = name
-            self._track_element(element_type, len(config_data))
+                f.write(json.dumps(
+                    d, indent=4,
+                    sort_keys=True).encode('ascii'))
+            self.tar_manifest[0]['Config'] = \
+                element.name
+            self._track_element(
+                element.element_type, len(config_data))
 
-        elif element_type == constants.IMAGE_LAYER:
-            layer_dir = os.path.join(self.image_path, name)
+        elif element.element_type == \
+                constants.IMAGE_LAYER:
+            layer_dir = os.path.join(
+                self.image_path, element.name)
             if not os.path.exists(layer_dir):
                 os.makedirs(layer_dir)
 
-            layer_file = os.path.join(name, 'layer.tar')
-            self.tar_manifest[0]['Layers'].append(layer_file)
+            layer_file = os.path.join(
+                element.name, 'layer.tar')
 
-            layer_file_in_dir = os.path.join(self.image_path, layer_file)
+            if element.layer_index is not None:
+                self._indexed_layers.append(
+                    (element.layer_index, layer_file))
+            else:
+                self.tar_manifest[0][
+                    'Layers'].append(layer_file)
+
+            layer_file_in_dir = os.path.join(
+                self.image_path, layer_file)
             layer_size = 0
             if os.path.exists(layer_file_in_dir):
-                LOG.info('Skipping layer already in output directory')
-                layer_size = os.path.getsize(layer_file_in_dir)
+                LOG.info(
+                    'Skipping layer already in'
+                    ' output directory')
+                layer_size = os.path.getsize(
+                    layer_file_in_dir)
             else:
-                with open(layer_file_in_dir, 'wb') as f:
-                    d = data.read(102400)
+                with open(
+                        layer_file_in_dir, 'wb') as f:
+                    d = element.data.read(102400)
                     while d:
                         layer_size += len(d)
                         f.write(d)
-                        d = data.read(102400)
+                        d = element.data.read(102400)
 
-                layer_dir_in_dir = os.path.join(self.image_path, name, 'layer')
+                layer_dir_in_dir = os.path.join(
+                    self.image_path, element.name,
+                    'layer')
                 os.makedirs(layer_dir_in_dir)
-                with tarfile.open(layer_file_in_dir) as layer:
+                with tarfile.open(
+                        layer_file_in_dir) as layer:
                     for mem in layer.getmembers():
-                        dirname, filename = os.path.split(mem.name)
+                        dirname, filename = \
+                            os.path.split(mem.name)
 
-                        # Some light reading on how this works...
+                        # Some light reading on how this
+                        # works...
                         # https://www.madebymikal.com/interpreting-whiteout-files-in-docker-image-layers/
                         # https://github.com/opencontainers/image-spec/blob/main/layer.md#opaque-whiteout
                         if filename == '.wh..wh..opq':
-                            # A deleted directory, but only for layers below
-                            # this one.
-                            os.setxattr(os.path.join(layer_dir_in_dir, dirname),
-                                        'trusted.overlay.opaque', b'y')
+                            # A deleted directory, but
+                            # only for layers below this
+                            # one.
+                            os.setxattr(
+                                os.path.join(
+                                    layer_dir_in_dir,
+                                    dirname),
+                                'trusted.overlay.opaque',
+                                b'y')
 
-                        elif filename.startswith('.wh.'):
-                            # A single deleted element, which might not be a
-                            # file.
-                            os.mknod(os.path.join(layer_dir_in_dir,
-                                     mem.name[4:]),
-                                     mode=stat.S_IFCHR, device=0)
+                        elif filename.startswith(
+                                '.wh.'):
+                            # A single deleted element,
+                            # which might not be a file.
+                            os.mknod(
+                                os.path.join(
+                                    layer_dir_in_dir,
+                                    mem.name[4:]),
+                                mode=stat.S_IFCHR,
+                                device=0)
 
                         else:
                             path = mem.name
-                            layer.extract(path, path=layer_dir_in_dir)
+                            layer.extract(
+                                path,
+                                path=layer_dir_in_dir)
 
-            self._track_element(element_type, layer_size)
+            self._track_element(
+                element.element_type, layer_size)
 
     def finalize(self):
+        # Reconstruct layer order from indices
+        if self._indexed_layers:
+            self._indexed_layers.sort(
+                key=lambda x: x[0])
+            self.tar_manifest[0]['Layers'] = [
+                name for _, name
+                in self._indexed_layers]
+
         manifest_filename = self._manifest_filename() + '.json'
         manifest_path = os.path.join(self.image_path, manifest_filename)
         with open(manifest_path, 'wb') as f:

--- a/occystrap/outputs/registry.py
+++ b/occystrap/outputs/registry.py
@@ -79,9 +79,11 @@ class RegistryWriter(ImageOutput):
         self._moniker = 'https' if secure else 'http'
         self._auth_lock = threading.Lock()
 
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers)
         self._config_future = None
-        self._layer_futures = []  # List of futures that return layer metadata
+        # List of (layer_index, future) tuples
+        self._layer_futures = []
 
         self._config_digest = None
         self._config_size = None
@@ -99,12 +101,16 @@ class RegistryWriter(ImageOutput):
         self._cached_layers = {}  # digest -> cached metadata
         self._cache_hits = 0
 
-        # Original DiffIDs from fetch_callback, consumed in
-        # process_image_element order.  Needed because filters
-        # may transform layer names (recalculating SHA256 after
-        # modifying content), but the cache must be keyed by
-        # the original input DiffID.
+        # Original DiffIDs from fetch_callback, consumed
+        # in process_image_element order.  Needed because
+        # filters may transform layer names (recalculating
+        # SHA256 after modifying content), but the cache
+        # must be keyed by the original input DiffID.
         self._original_digests = deque()
+
+    @property
+    def requires_ordered_layers(self):
+        return False
 
     def _request(self, method, url, headers=None, data=None, stream=False):
         """Make an authenticated request to the registry.
@@ -297,88 +303,113 @@ class RegistryWriter(ImageOutput):
             digest[:19], entry['compressed_digest'][:19])
         return True
 
-    def process_image_element(self, element_type, name, data):
-        """Process an image element, uploading it to the registry.
+    def process_image_element(self, element):
+        """Process an image element, uploading it to
+        the registry.
 
-        Both compression and uploads are submitted to a thread pool for
-        parallel execution. This allows multiple layers to compress and
-        upload simultaneously.
+        Both compression and uploads are submitted to
+        a thread pool for parallel execution. This
+        allows multiple layers to compress and upload
+        simultaneously.
         """
-        # Track start time (can't use _track_element because we track
-        # compressed sizes which are only known after compression)
+        # Track start time (can't use _track_element
+        # because we track compressed sizes which are
+        # only known after compression)
         if self._start_time is None:
             self._start_time = time.time()
 
-        if element_type == constants.CONFIG_FILE and data is not None:
+        if (element.element_type == constants.CONFIG_FILE
+                and element.data is not None):
             LOG.info('Processing config file')
 
-            data.seek(0)
-            config_data = data.read()
+            element.data.seek(0)
+            config_data = element.data.read()
 
             h = hashlib.sha256()
             h.update(config_data)
-            self._config_digest = f'sha256:{h.hexdigest()}'
+            self._config_digest = \
+                f'sha256:{h.hexdigest()}'
             self._config_size = len(config_data)
 
             # Submit config upload to thread pool
-            self._config_future = self._executor.submit(
-                self._upload_blob, self._config_digest,
-                io.BytesIO(config_data), self._config_size)
+            self._config_future = \
+                self._executor.submit(
+                    self._upload_blob,
+                    self._config_digest,
+                    io.BytesIO(config_data),
+                    self._config_size)
 
-        elif element_type == constants.IMAGE_LAYER and data is not None:
-            # Use the original DiffID for cache recording;
-            # filters may have transformed `name` by
-            # recalculating the hash after modifying content.
-            # Falls back to `name` when fetch_callback was not
+        elif (element.element_type
+                == constants.IMAGE_LAYER
+                and element.data is not None):
+            # Use the original DiffID for cache
+            # recording; filters may have transformed
+            # `name` by recalculating the hash after
+            # modifying content. Falls back to
+            # element.name when fetch_callback was not
             # called (e.g., in unit tests).
             if self._original_digests:
                 original_digest = (
                     self._original_digests.popleft())
             else:
-                original_digest = name
-            LOG.info(f'Processing layer {name}')
+                original_digest = element.name
+            LOG.info(
+                'Processing layer %s'
+                % element.name)
 
-            data.seek(0)
-            layer_data = data.read()
+            element.data.seek(0)
+            layer_data = element.data.read()
 
-            # Submit compression + upload to thread pool
-            # This allows multiple layers to compress in parallel
+            # Submit compression + upload to thread
+            # pool for parallel compression
             future = self._executor.submit(
                 self._compress_and_upload_layer,
                 layer_data, original_digest)
-            self._layer_futures.append(future)
+            self._layer_futures.append(
+                (element.layer_index, future))
 
-        elif element_type == constants.IMAGE_LAYER and data is None:
+        elif (element.element_type
+                == constants.IMAGE_LAYER
+                and element.data is None):
             if self._original_digests:
                 original_digest = (
                     self._original_digests.popleft())
             else:
-                original_digest = name
-            # Layer was skipped by fetch_callback - check cache
+                original_digest = element.name
+            # Layer was skipped by fetch_callback -
+            # check cache
             if original_digest in self._cached_layers:
-                entry = self._cached_layers[original_digest]
+                entry = \
+                    self._cached_layers[original_digest]
                 f = Future()
                 f.set_result({
                     'mediaType': entry['media_type'],
                     'size': entry['compressed_size'],
-                    'digest': entry['compressed_digest']
+                    'digest': entry[
+                        'compressed_digest']
                 })
-                self._layer_futures.append(f)
-                # _cache_hits is only updated from the main
-                # thread (process_image_element is not called
-                # from worker threads), so no lock is needed.
+                self._layer_futures.append(
+                    (element.layer_index, f))
+                # _cache_hits is only updated from the
+                # main thread (process_image_element is
+                # not called from worker threads), so
+                # no lock is needed.
                 self._cache_hits += 1
 
     def finalize(self):
         """Push the image manifest to the registry.
 
-        Waits for all parallel compression/uploads to complete before
-        pushing the manifest. Layer metadata is collected from futures
-        in order to build the manifest.
+        Waits for all parallel compression/uploads to
+        complete before pushing the manifest. Layer
+        metadata is collected from futures and sorted
+        by layer_index to build the manifest in correct
+        order.
         """
         total_layers = len(self._layer_futures)
-        LOG.info(f'Waiting for {total_layers} layer compression/uploads '
-                 'to complete...')
+        LOG.info(
+            'Waiting for %d layer'
+            ' compression/uploads to complete...'
+            % total_layers)
 
         errors = []
 
@@ -388,33 +419,54 @@ class RegistryWriter(ImageOutput):
                 self._config_future.result()
                 LOG.info('Config uploaded')
             except Exception as e:
-                errors.append(f'Config upload: {e}')
+                errors.append('Config upload: %s' % e)
 
-        # Collect layer metadata from futures, preserving order
-        # Report progress on a wall clock cadence (every 10 seconds)
-        layers = []
+        # Collect layer metadata from futures
+        # Each entry is (layer_index, future)
+        indexed_layers = []
+        unindexed_layers = []
         completed = 0
         last_report_time = time.time()
         progress_interval = 10  # seconds
 
-        for i, future in enumerate(self._layer_futures):
+        for i, (layer_index, future) in enumerate(
+                self._layer_futures):
             try:
                 layer_metadata = future.result()
-                layers.append(layer_metadata)
+                if layer_index is not None:
+                    indexed_layers.append(
+                        (layer_index, layer_metadata))
+                else:
+                    unindexed_layers.append(
+                        layer_metadata)
                 completed += 1
 
                 # Report progress every 10 seconds
                 now = time.time()
-                if now - last_report_time >= progress_interval:
-                    remaining = total_layers - completed
-                    LOG.info(f'Progress: {completed}/{total_layers} layers '
-                             f'complete, {remaining} remaining')
+                if (now - last_report_time
+                        >= progress_interval):
+                    remaining = (
+                        total_layers - completed)
+                    LOG.info(
+                        'Progress: %d/%d layers'
+                        ' complete, %d remaining'
+                        % (completed, total_layers,
+                           remaining))
                     last_report_time = now
 
             except Exception as e:
-                errors.append(f'Layer {i}: {e}')
+                errors.append('Layer %d: %s' % (i, e))
 
         self._executor.shutdown(wait=True)
+
+        # Reconstruct layer order from indices
+        if indexed_layers:
+            indexed_layers.sort(
+                key=lambda x: x[0])
+            layers = [
+                meta for _, meta in indexed_layers]
+        else:
+            layers = unindexed_layers
 
         if errors:
             raise Exception(f'Upload failed: {"; ".join(errors)}')

--- a/occystrap/outputs/tarfile.py
+++ b/occystrap/outputs/tarfile.py
@@ -19,11 +19,12 @@ LOG.setLevel(logging.INFO)
 class TarWriter(ImageOutput):
     """Creates docker-loadable tarballs in v1.2 format.
 
-    To normalize timestamps for reproducible builds, use the
-    TimestampNormalizer filter before this output.
+    To normalize timestamps for reproducible builds, use
+    the TimestampNormalizer filter before this output.
 
-    Uses USTAR format for the outer tarball which contains only short paths
-    (SHA256 hashes and small filenames), avoiding PAX extended headers.
+    Uses USTAR format for the outer tarball which
+    contains only short paths (SHA256 hashes and small
+    filenames), avoiding PAX extended headers.
     """
 
     def __init__(self, image, tag, image_path):
@@ -32,45 +33,72 @@ class TarWriter(ImageOutput):
         self.image = image
         self.tag = tag
         self.image_path = image_path
-        self.image_tar = tarfile.open(image_path, 'w',
-                                      format=tarfile.USTAR_FORMAT)
+        self.image_tar = tarfile.open(
+            image_path, 'w', format=tarfile.USTAR_FORMAT)
 
         self.tar_manifest = [{
             'Layers': [],
-            'RepoTags': ['%s:%s' % (self.image.split('/')[-1], self.tag)]
+            'RepoTags': [
+                '%s:%s' % (self.image.split('/')[-1],
+                           self.tag)]
         }]
+
+        # For out-of-order layer delivery
+        self._indexed_layers = []
+
+    @property
+    def requires_ordered_layers(self):
+        return False
 
     def fetch_callback(self, digest):
         return True
 
-    def process_image_element(self, element_type, name, data):
-        if element_type == constants.CONFIG_FILE:
+    def process_image_element(self, element):
+        if element.element_type == constants.CONFIG_FILE:
             LOG.info('Writing config file to tarball')
 
-            ti = tarfile.TarInfo(name)
-            ti.size = len(data.read())
-            data.seek(0)
-            self.image_tar.addfile(ti, data)
-            self.tar_manifest[0]['Config'] = name
-            self._track_element(element_type, ti.size)
+            ti = tarfile.TarInfo(element.name)
+            ti.size = len(element.data.read())
+            element.data.seek(0)
+            self.image_tar.addfile(ti, element.data)
+            self.tar_manifest[0]['Config'] = element.name
+            self._track_element(
+                element.element_type, ti.size)
 
-        elif element_type == constants.IMAGE_LAYER:
+        elif element.element_type == constants.IMAGE_LAYER:
             LOG.info('Writing layer to tarball')
 
-            name += '/layer.tar'
-            ti = tarfile.TarInfo(name)
-            data.seek(0, os.SEEK_END)
-            ti.size = data.tell()
-            data.seek(0)
-            self.image_tar.addfile(ti, data)
-            self.tar_manifest[0]['Layers'].append(name)
-            self._track_element(element_type, ti.size)
+            layer_name = element.name + '/layer.tar'
+            ti = tarfile.TarInfo(layer_name)
+            element.data.seek(0, os.SEEK_END)
+            ti.size = element.data.tell()
+            element.data.seek(0)
+            self.image_tar.addfile(ti, element.data)
+            self._track_element(
+                element.element_type, ti.size)
+
+            if element.layer_index is not None:
+                self._indexed_layers.append(
+                    (element.layer_index, layer_name))
+            else:
+                self.tar_manifest[0][
+                    'Layers'].append(layer_name)
 
     def finalize(self):
+        # Reconstruct layer order from indices
+        if self._indexed_layers:
+            self._indexed_layers.sort(
+                key=lambda x: x[0])
+            self.tar_manifest[0]['Layers'] = [
+                name for _, name
+                in self._indexed_layers]
+
         LOG.info('Writing manifest file to tarball')
-        encoded_manifest = json.dumps(self.tar_manifest).encode('utf-8')
+        encoded_manifest = json.dumps(
+            self.tar_manifest).encode('utf-8')
         ti = tarfile.TarInfo('manifest.json')
         ti.size = len(encoded_manifest)
-        self.image_tar.addfile(ti, io.BytesIO(encoded_manifest))
+        self.image_tar.addfile(
+            ti, io.BytesIO(encoded_manifest))
         self.image_tar.close()
         self._log_summary()

--- a/occystrap/tests/test_inspect.py
+++ b/occystrap/tests/test_inspect.py
@@ -15,8 +15,8 @@ class TestInspectFilter(unittest.TestCase):
     """Tests for the InspectFilter class."""
 
     def setUp(self):
-        self.output_fd, self.output_file = tempfile.mkstemp(
-            suffix='.jsonl')
+        self.output_fd, self.output_file = \
+            tempfile.mkstemp(suffix='.jsonl')
         os.close(self.output_fd)
         # Start with an empty file
         with open(self.output_file, 'w') as f:
@@ -30,8 +30,9 @@ class TestInspectFilter(unittest.TestCase):
         """Create a config JSON file-like object.
 
         Args:
-            history_entries: List of dicts, each with optional
-                keys: created, created_by, comment, empty_layer.
+            history_entries: List of dicts, each with
+                optional keys: created, created_by,
+                comment, empty_layer.
         """
         config = {
             'history': history_entries,
@@ -47,14 +48,15 @@ class TestInspectFilter(unittest.TestCase):
         """Create a layer tarball file-like object.
 
         Args:
-            files: List of (name, content) tuples. Defaults to
-                a single file.
+            files: List of (name, content) tuples.
+                Defaults to a single file.
         """
         if files is None:
             files = [('file.txt', b'hello')]
 
         buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode='w') as tar:
+        with tarfile.open(
+                fileobj=buf, mode='w') as tar:
             for name, content in files:
                 ti = tarfile.TarInfo(name=name)
                 ti.size = len(content)
@@ -62,8 +64,14 @@ class TestInspectFilter(unittest.TestCase):
         buf.seek(0)
         return buf
 
+    def _elem(self, element_type, name, data):
+        """Helper to create an ImageElement."""
+        return constants.ImageElement(
+            element_type, name, data)
+
     def test_basic_output(self):
-        """Test that inspect produces valid JSONL output."""
+        """Test that inspect produces valid JSONL
+        output."""
         f = InspectFilter(
             None, self.output_file,
             image='myimage', tag='v1')
@@ -71,16 +79,19 @@ class TestInspectFilter(unittest.TestCase):
         config = self._make_config([
             {
                 'created': '2025-01-15T10:00:00Z',
-                'created_by': '/bin/sh -c echo hello',
+                'created_by':
+                    '/bin/sh -c echo hello',
                 'comment': '',
             },
         ])
         layer = self._make_layer()
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'abc123', layer)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'abc123', layer))
         f.finalize()
 
         with open(self.output_file) as fh:
@@ -88,7 +99,8 @@ class TestInspectFilter(unittest.TestCase):
 
         self.assertEqual(len(lines), 1)
         record = json.loads(lines[0])
-        self.assertEqual(record['name'], 'myimage:v1')
+        self.assertEqual(
+            record['name'], 'myimage:v1')
         self.assertEqual(len(record['layers']), 1)
 
         layer_entry = record['layers'][0]
@@ -98,10 +110,12 @@ class TestInspectFilter(unittest.TestCase):
         self.assertEqual(
             layer_entry['CreatedBy'],
             '/bin/sh -c echo hello')
-        self.assertEqual(layer_entry['Tags'], ['myimage:v1'])
+        self.assertEqual(
+            layer_entry['Tags'], ['myimage:v1'])
 
     def test_empty_layer_history_skipped(self):
-        """Test that empty_layer history entries are skipped."""
+        """Test that empty_layer history entries are
+        skipped."""
         f = InspectFilter(
             None, self.output_file,
             image='img', tag='latest')
@@ -109,16 +123,19 @@ class TestInspectFilter(unittest.TestCase):
         config = self._make_config([
             {
                 'created': '2025-01-15T10:00:00Z',
-                'created_by': '/bin/sh -c apt-get install',
+                'created_by':
+                    '/bin/sh -c apt-get install',
             },
             {
                 'created': '2025-01-15T10:01:00Z',
-                'created_by': '/bin/sh -c #(nop) ENV FOO=bar',
+                'created_by':
+                    '/bin/sh -c #(nop) ENV FOO=bar',
                 'empty_layer': True,
             },
             {
                 'created': '2025-01-15T10:02:00Z',
-                'created_by': '/bin/sh -c echo done',
+                'created_by':
+                    '/bin/sh -c echo done',
             },
         ])
         layer1 = self._make_layer(
@@ -126,12 +143,15 @@ class TestInspectFilter(unittest.TestCase):
         layer2 = self._make_layer(
             [('done.txt', b'done')])
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'layer1hash', layer1)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'layer2hash', layer2)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'layer1hash', layer1))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'layer2hash', layer2))
         f.finalize()
 
         with open(self.output_file) as fh:
@@ -161,13 +181,15 @@ class TestInspectFilter(unittest.TestCase):
         layer1 = self._make_layer()
         layer2 = self._make_layer()
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'abc123', layer1)
-        f.process_image_element(
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
             constants.IMAGE_LAYER,
-            'sha256:def456', layer2)
+            'abc123', layer1))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'sha256:def456', layer2))
         f.finalize()
 
         with open(self.output_file) as fh:
@@ -175,12 +197,15 @@ class TestInspectFilter(unittest.TestCase):
 
         # Reversed order
         self.assertEqual(
-            record['layers'][0]['Id'], 'sha256:def456')
+            record['layers'][0]['Id'],
+            'sha256:def456')
         self.assertEqual(
-            record['layers'][1]['Id'], 'sha256:abc123')
+            record['layers'][1]['Id'],
+            'sha256:abc123')
 
     def test_append_mode(self):
-        """Test that multiple invocations append to the file."""
+        """Test that multiple invocations append to
+        the file."""
         for i in range(3):
             f = InspectFilter(
                 None, self.output_file,
@@ -188,10 +213,12 @@ class TestInspectFilter(unittest.TestCase):
             config = self._make_config(
                 [{'created_by': 'step'}])
             layer = self._make_layer()
-            f.process_image_element(
-                constants.CONFIG_FILE, 'cfg', config)
-            f.process_image_element(
-                constants.IMAGE_LAYER, 'hash%d' % i, layer)
+            f.process_image_element(self._elem(
+                constants.CONFIG_FILE,
+                'cfg', config))
+            f.process_image_element(self._elem(
+                constants.IMAGE_LAYER,
+                'hash%d' % i, layer))
             f.finalize()
 
         with open(self.output_file) as fh:
@@ -204,15 +231,22 @@ class TestInspectFilter(unittest.TestCase):
                 record['name'], 'img%d:v1' % i)
 
     def test_passthrough_mode(self):
-        """Test that elements are passed to wrapped output."""
+        """Test that elements are passed to wrapped
+        output."""
         received = []
 
         class MockOutput:
+            @property
+            def requires_ordered_layers(self):
+                return True
+
             def fetch_callback(self, digest):
                 return True
 
-            def process_image_element(self, et, name, data):
-                received.append((et, name))
+            def process_image_element(self, element):
+                received.append(
+                    (element.element_type,
+                     element.name))
 
             def finalize(self):
                 pass
@@ -226,17 +260,21 @@ class TestInspectFilter(unittest.TestCase):
             [{'created_by': 'step'}])
         layer = self._make_layer()
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'abc123', layer)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'abc123', layer))
         f.finalize()
 
         self.assertEqual(len(received), 2)
         self.assertEqual(
-            received[0], (constants.CONFIG_FILE, 'config.json'))
+            received[0],
+            (constants.CONFIG_FILE, 'config.json'))
         self.assertEqual(
-            received[1], (constants.IMAGE_LAYER, 'abc123'))
+            received[1],
+            (constants.IMAGE_LAYER, 'abc123'))
 
         # Output file should also have been written
         with open(self.output_file) as fh:
@@ -244,14 +282,16 @@ class TestInspectFilter(unittest.TestCase):
         self.assertEqual(record['name'], 'img:v1')
 
     def test_no_config(self):
-        """Test graceful handling when no config is provided."""
+        """Test graceful handling when no config is
+        provided."""
         f = InspectFilter(
             None, self.output_file,
             image='img', tag='v1')
 
         layer = self._make_layer()
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'abc123', layer)
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'abc123', layer))
         f.finalize()
 
         with open(self.output_file) as fh:
@@ -270,20 +310,24 @@ class TestInspectFilter(unittest.TestCase):
 
         config = self._make_config(
             [{'created_by': 'step'}])
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'abc123', None)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'abc123', None))
         f.finalize()
 
         with open(self.output_file) as fh:
             record = json.loads(fh.readline())
 
         self.assertEqual(len(record['layers']), 1)
-        self.assertEqual(record['layers'][0]['Size'], 0)
+        self.assertEqual(
+            record['layers'][0]['Size'], 0)
 
     def test_tags_on_topmost_layer_only(self):
-        """Test that Tags is set only on the topmost layer."""
+        """Test that Tags is set only on the topmost
+        layer."""
         f = InspectFilter(
             None, self.output_file,
             image='myimg', tag='latest')
@@ -295,55 +339,66 @@ class TestInspectFilter(unittest.TestCase):
         layer1 = self._make_layer()
         layer2 = self._make_layer()
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'base', layer1)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'app', layer2)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'base', layer1))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'app', layer2))
         f.finalize()
 
         with open(self.output_file) as fh:
             record = json.loads(fh.readline())
 
-        # Reversed: app is first (topmost), base is second
+        # Reversed: app is first (topmost), base is
+        # second
         self.assertEqual(
             record['layers'][0]['Tags'],
             ['myimg:latest'])
-        self.assertIsNone(record['layers'][1]['Tags'])
+        self.assertIsNone(
+            record['layers'][1]['Tags'])
 
     def test_created_timestamp_parsing(self):
-        """Test various timestamp formats in config history."""
+        """Test various timestamp formats in config
+        history."""
         f = InspectFilter(
             None, self.output_file,
             image='img', tag='v1')
 
         config = self._make_config([
             {
-                'created': '2025-06-15T12:30:45Z',
+                'created':
+                    '2025-06-15T12:30:45Z',
                 'created_by': 'iso-utc',
             },
             {
-                'created': '2025-06-15T12:30:45+00:00',
+                'created':
+                    '2025-06-15T12:30:45+00:00',
                 'created_by': 'iso-offset',
             },
         ])
         layer1 = self._make_layer()
         layer2 = self._make_layer()
 
-        f.process_image_element(
-            constants.CONFIG_FILE, 'config.json', config)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'l1', layer1)
-        f.process_image_element(
-            constants.IMAGE_LAYER, 'l2', layer2)
+        f.process_image_element(self._elem(
+            constants.CONFIG_FILE,
+            'config.json', config))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'l1', layer1))
+        f.process_image_element(self._elem(
+            constants.IMAGE_LAYER,
+            'l2', layer2))
         f.finalize()
 
         with open(self.output_file) as fh:
             record = json.loads(fh.readline())
 
         # Both should parse to the same timestamp
-        ts1 = record['layers'][1]['Created']  # reversed
+        ts1 = record['layers'][1]['Created']
         ts2 = record['layers'][0]['Created']
         self.assertIsInstance(ts1, int)
         self.assertIsInstance(ts2, int)

--- a/occystrap/tests/test_registry_output.py
+++ b/occystrap/tests/test_registry_output.py
@@ -13,6 +13,11 @@ from occystrap.outputs import registry as output_registry
 
 
 class RegistryWriterTestCase(unittest.TestCase):
+    def _elem(self, element_type, name, data):
+        """Helper to create an ImageElement."""
+        return constants.ImageElement(
+            element_type, name, data)
+
     def test_initialization(self):
         """Test RegistryWriter initializes with correct attributes."""
         writer = output_registry.RegistryWriter(
@@ -148,9 +153,10 @@ class RegistryWriterTestCase(unittest.TestCase):
         }).encode('utf-8')
 
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         self.assertIsNotNone(writer._config_digest)
         self.assertTrue(writer._config_digest.startswith('sha256:'))
@@ -176,17 +182,20 @@ class RegistryWriterTestCase(unittest.TestCase):
         mock_request.side_effect = mock_request_handler
 
         # Add config (required for finalize)
-        config_data = json.dumps({'architecture': 'amd64'}).encode('utf-8')
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode('utf-8')
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         layer_data = b'test layer content'
         writer.process_image_element(
-            constants.IMAGE_LAYER,
-            'sha256_original',
-            io.BytesIO(layer_data))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_original',
+                io.BytesIO(layer_data)))
 
         # Finalize to collect layer metadata from futures
         writer.finalize()
@@ -218,7 +227,8 @@ class RegistryWriterTestCase(unittest.TestCase):
             elif method == 'POST':
                 response.status_code = 202
                 response.headers = {
-                    'Location': '/v2/myuser/myimage/blobs/uploads/uuid123'
+                    'Location':
+                        '/v2/myuser/myimage/blobs/uploads/uuid123'
                 }
             elif method == 'PUT' and '/manifests/' in url:
                 response.status_code = 201
@@ -231,17 +241,20 @@ class RegistryWriterTestCase(unittest.TestCase):
         mock_request.side_effect = mock_request_handler
 
         # Add config (required for finalize)
-        config_data = json.dumps({'architecture': 'amd64'}).encode('utf-8')
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode('utf-8')
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         layer_data = b'test layer content'
         writer.process_image_element(
-            constants.IMAGE_LAYER,
-            'sha256_original',
-            io.BytesIO(layer_data))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_original',
+                io.BytesIO(layer_data)))
 
         # Finalize to collect layer metadata
         writer.finalize()
@@ -261,12 +274,14 @@ class RegistryWriterTestCase(unittest.TestCase):
         manifest_data = last_call[1]['data']
         manifest = json.loads(manifest_data.decode('utf-8'))
 
-        self.assertEqual(expected_digest, manifest['layers'][0]['digest'])
+        self.assertEqual(
+            expected_digest, manifest['layers'][0]['digest'])
 
     @mock.patch('occystrap.outputs.registry.requests.request')
     def test_finalize_pushes_manifest(self, mock_request):
         """Test that finalize pushes the manifest."""
-        # Use max_workers=1 for predictable call ordering with mocks
+        # Use max_workers=1 for predictable call ordering
+        # with mocks
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
 
@@ -286,18 +301,21 @@ class RegistryWriterTestCase(unittest.TestCase):
         mock_request.side_effect = mock_request_handler
 
         # Add config
-        config_data = json.dumps({'architecture': 'amd64'}).encode('utf-8')
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode('utf-8')
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         # Add layer
         layer_data = b'test layer'
         writer.process_image_element(
-            constants.IMAGE_LAYER,
-            'sha256_layer',
-            io.BytesIO(layer_data))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_layer',
+                io.BytesIO(layer_data)))
 
         writer.finalize()
 
@@ -306,11 +324,13 @@ class RegistryWriterTestCase(unittest.TestCase):
         self.assertEqual('PUT', last_call[0][0])
         self.assertIn('/manifests/v1.0', last_call[0][1])
         self.assertEqual(
-            'application/vnd.docker.distribution.manifest.v2+json',
+            'application/vnd.docker.distribution.'
+            'manifest.v2+json',
             last_call[1]['headers']['Content-Type'])
 
     @mock.patch('occystrap.outputs.registry.requests.request')
-    def test_finalize_without_config_raises_error(self, mock_request):
+    def test_finalize_without_config_raises_error(
+            self, mock_request):
         """Test that finalize raises error if no config was processed."""
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0')
@@ -333,32 +353,39 @@ class RegistryWriterTestCase(unittest.TestCase):
         auth_response.status_code = 401
         auth_response.headers = {
             'Www-Authenticate':
-                'Bearer realm="https://ghcr.io/token",service="ghcr.io"'
+                'Bearer realm="https://ghcr.io/token"'
+                ',service="ghcr.io"'
         }
 
         # Token request
         token_response = mock.MagicMock()
         token_response.status_code = 200
-        token_response.json.return_value = {'token': 'test_token'}
+        token_response.json.return_value = {
+            'token': 'test_token'
+        }
         mock_get.return_value = token_response
 
         # Retry after auth succeeds
         success_response = mock.MagicMock()
         success_response.status_code = 200
 
-        mock_request.side_effect = [auth_response, success_response]
+        mock_request.side_effect = [
+            auth_response, success_response
+        ]
 
         writer._blob_exists('sha256:abc123')
 
         # Verify token was requested with auth
         mock_get.assert_called_once()
         call_kwargs = mock_get.call_args[1]
-        self.assertEqual(('user', 'token'), call_kwargs['auth'])
+        self.assertEqual(
+            ('user', 'token'), call_kwargs['auth'])
 
     @mock.patch('occystrap.outputs.registry.requests.request')
     def test_manifest_format(self, mock_request):
         """Test that manifest has correct format."""
-        # Use max_workers=1 for predictable call ordering with mocks
+        # Use max_workers=1 for predictable call ordering
+        # with mocks
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
 
@@ -378,17 +405,20 @@ class RegistryWriterTestCase(unittest.TestCase):
         mock_request.side_effect = mock_request_handler
 
         # Process config and layer
-        config_data = json.dumps({'architecture': 'amd64'}).encode('utf-8')
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode('utf-8')
         writer.process_image_element(
-            constants.CONFIG_FILE,
-            'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         layer_data = b'test layer'
         writer.process_image_element(
-            constants.IMAGE_LAYER,
-            'sha256_layer',
-            io.BytesIO(layer_data))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_layer',
+                io.BytesIO(layer_data)))
 
         writer.finalize()
 
@@ -399,11 +429,14 @@ class RegistryWriterTestCase(unittest.TestCase):
 
         self.assertEqual(2, manifest['schemaVersion'])
         self.assertEqual(
-            'application/vnd.docker.distribution.manifest.v2+json',
+            'application/vnd.docker.distribution.'
+            'manifest.v2+json',
             manifest['mediaType'])
         self.assertIn('config', manifest)
         self.assertIn('layers', manifest)
-        self.assertEqual(writer._config_digest, manifest['config']['digest'])
+        self.assertEqual(
+            writer._config_digest,
+            manifest['config']['digest'])
         self.assertEqual(1, len(manifest['layers']))
 
     def test_timing_fields_initialized(self):
@@ -416,7 +449,8 @@ class RegistryWriterTestCase(unittest.TestCase):
         self.assertEqual(0, writer._upload_skipped)
 
     @mock.patch('occystrap.outputs.registry.requests.request')
-    def test_timing_fields_populated_after_finalize(self, mock_request):
+    def test_timing_fields_populated_after_finalize(
+            self, mock_request):
         """Test that timing fields are populated after processing."""
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
@@ -433,26 +467,35 @@ class RegistryWriterTestCase(unittest.TestCase):
 
         mock_request.side_effect = mock_request_handler
 
-        config_data = json.dumps({'architecture': 'amd64'}).encode()
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode()
         writer.process_image_element(
-            constants.CONFIG_FILE, 'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         layer_data = b'test layer content for timing'
         writer.process_image_element(
-            constants.IMAGE_LAYER, 'sha256_layer',
-            io.BytesIO(layer_data))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_layer',
+                io.BytesIO(layer_data)))
 
         writer.finalize()
 
-        self.assertGreater(writer._total_compress_time, 0.0)
-        self.assertGreater(writer._total_upload_time, 0.0)
-        self.assertEqual(len(layer_data), writer._total_input_bytes)
+        self.assertGreater(
+            writer._total_compress_time, 0.0)
+        self.assertGreater(
+            writer._total_upload_time, 0.0)
+        self.assertEqual(
+            len(layer_data), writer._total_input_bytes)
         # Blob existed, so upload was skipped
         self.assertEqual(1, writer._upload_skipped)
 
     @mock.patch('occystrap.outputs.registry.requests.request')
-    def test_upload_blob_returns_true_when_exists(self, mock_request):
+    def test_upload_blob_returns_true_when_exists(
+            self, mock_request):
         """Test _upload_blob returns True when blob already exists."""
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0')
@@ -466,7 +509,8 @@ class RegistryWriterTestCase(unittest.TestCase):
         self.assertTrue(result)
 
     @mock.patch('occystrap.outputs.registry.requests.request')
-    def test_upload_blob_returns_false_when_uploaded(self, mock_request):
+    def test_upload_blob_returns_false_when_uploaded(
+            self, mock_request):
         """Test _upload_blob returns False when blob is uploaded."""
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0')
@@ -477,7 +521,8 @@ class RegistryWriterTestCase(unittest.TestCase):
         post_response = mock.MagicMock()
         post_response.status_code = 202
         post_response.headers = {
-            'Location': '/v2/myuser/myimage/blobs/uploads/uuid123'
+            'Location':
+                '/v2/myuser/myimage/blobs/uploads/uuid123'
         }
 
         put_response = mock.MagicMock()
@@ -496,7 +541,8 @@ class RegistryWriterTestCase(unittest.TestCase):
             self, mock_request):
         """Test upload_skipped counts correctly with multiple layers."""
         writer = output_registry.RegistryWriter(
-            'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
+            'ghcr.io', 'myuser/myimage', 'v1.0',
+            max_workers=1)
 
         call_count = [0]
 
@@ -505,7 +551,8 @@ class RegistryWriterTestCase(unittest.TestCase):
             if method == 'HEAD':
                 call_count[0] += 1
                 # First two HEAD checks: blob exists (skip)
-                # Third HEAD check: blob doesn't exist (upload)
+                # Third HEAD check: blob doesn't exist
+                # (upload)
                 if call_count[0] <= 3:
                     response.status_code = 200
                 else:
@@ -525,22 +572,28 @@ class RegistryWriterTestCase(unittest.TestCase):
 
         mock_request.side_effect = mock_request_handler
 
-        config_data = json.dumps({'architecture': 'amd64'}).encode()
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode()
         writer.process_image_element(
-            constants.CONFIG_FILE, 'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         # Two layers where blob exists (skipped uploads)
         for i in range(2):
             writer.process_image_element(
-                constants.IMAGE_LAYER, f'sha256_layer{i}',
-                io.BytesIO(b'layer data'))
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    f'sha256_layer{i}',
+                    io.BytesIO(b'layer data')))
 
         writer.finalize()
 
         self.assertEqual(2, writer._upload_skipped)
-        self.assertEqual(2 * len(b'layer data'),
-                         writer._total_input_bytes)
+        self.assertEqual(
+            2 * len(b'layer data'),
+            writer._total_input_bytes)
 
 
 class RegistryWriterCacheTestCase(unittest.TestCase):
@@ -550,6 +603,11 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
     runtime behaviour -- input sources strip the prefix before
     calling fetch_callback.
     """
+
+    def _elem(self, element_type, name, data):
+        """Helper to create an ImageElement."""
+        return constants.ImageElement(
+            element_type, name, data)
 
     @mock.patch('occystrap.outputs.registry.requests.request')
     def test_fetch_callback_without_cache(self, mock_request):
@@ -629,17 +687,20 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
                 '.diff.tar.gzip')
 
             # Registry has the cached blob
-            def mock_request_handler(method, url, **kwargs):
+            def mock_request_handler(
+                    method, url, **kwargs):
                 response = mock.MagicMock()
                 if method == 'HEAD':
                     response.status_code = 200
-                elif method == 'PUT' and '/manifests/' in url:
+                elif (method == 'PUT'
+                      and '/manifests/' in url):
                     response.status_code = 201
                 else:
                     response.status_code = 200
                 return response
 
-            mock_request.side_effect = mock_request_handler
+            mock_request.side_effect = (
+                mock_request_handler)
 
             writer = output_registry.RegistryWriter(
                 'ghcr.io', 'myuser/myimage', 'v1.0',
@@ -653,12 +714,17 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             config_data = json.dumps(
                 {'architecture': 'amd64'}).encode()
             writer.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                io.BytesIO(config_data))
+                self._elem(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
             # Process cached layer (data=None)
             writer.process_image_element(
-                constants.IMAGE_LAYER, 'layer1hex', None)
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    'layer1hex',
+                    None))
 
             writer.finalize()
 
@@ -681,17 +747,20 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             cache_path = os.path.join(d, 'cache.json')
             cache = LayerCache(cache_path)
 
-            def mock_request_handler(method, url, **kwargs):
+            def mock_request_handler(
+                    method, url, **kwargs):
                 response = mock.MagicMock()
                 if method == 'HEAD':
                     response.status_code = 200
-                elif method == 'PUT' and '/manifests/' in url:
+                elif (method == 'PUT'
+                      and '/manifests/' in url):
                     response.status_code = 201
                 else:
                     response.status_code = 200
                 return response
 
-            mock_request.side_effect = mock_request_handler
+            mock_request.side_effect = (
+                mock_request_handler)
 
             writer = output_registry.RegistryWriter(
                 'ghcr.io', 'myuser/myimage', 'v1.0',
@@ -700,12 +769,16 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             config_data = json.dumps(
                 {'architecture': 'amd64'}).encode()
             writer.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                io.BytesIO(config_data))
+                self._elem(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
             writer.process_image_element(
-                constants.IMAGE_LAYER, 'input_layer_hex',
-                io.BytesIO(b'layer data'))
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    'input_layer_hex',
+                    io.BytesIO(b'layer data')))
 
             writer.finalize()
 
@@ -722,16 +795,19 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
                     'sha256:'))
 
     @mock.patch('occystrap.outputs.registry.requests.request')
-    def test_no_cache_backward_compatibility(self, mock_request):
+    def test_no_cache_backward_compatibility(
+            self, mock_request):
         """Test that registry push works without cache."""
         writer = output_registry.RegistryWriter(
-            'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
+            'ghcr.io', 'myuser/myimage', 'v1.0',
+            max_workers=1)
 
         def mock_request_handler(method, url, **kwargs):
             response = mock.MagicMock()
             if method == 'HEAD':
                 response.status_code = 200
-            elif method == 'PUT' and '/manifests/' in url:
+            elif (method == 'PUT'
+                  and '/manifests/' in url):
                 response.status_code = 201
             else:
                 response.status_code = 200
@@ -742,12 +818,16 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
         config_data = json.dumps(
             {'architecture': 'amd64'}).encode()
         writer.process_image_element(
-            constants.CONFIG_FILE, 'config.json',
-            io.BytesIO(config_data))
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
 
         writer.process_image_element(
-            constants.IMAGE_LAYER, 'sha256_layer',
-            io.BytesIO(b'layer data'))
+            self._elem(
+                constants.IMAGE_LAYER,
+                'sha256_layer',
+                io.BytesIO(b'layer data')))
 
         # Should complete without error
         writer.finalize()
@@ -770,17 +850,20 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             cache_path = os.path.join(d, 'cache.json')
             cache = LayerCache(cache_path)
 
-            def mock_request_handler(method, url, **kwargs):
+            def mock_request_handler(
+                    method, url, **kwargs):
                 response = mock.MagicMock()
                 if method == 'HEAD':
                     response.status_code = 200
-                elif method == 'PUT' and '/manifests/' in url:
+                elif (method == 'PUT'
+                      and '/manifests/' in url):
                     response.status_code = 201
                 else:
                     response.status_code = 200
                 return response
 
-            mock_request.side_effect = mock_request_handler
+            mock_request.side_effect = (
+                mock_request_handler)
 
             writer = output_registry.RegistryWriter(
                 'ghcr.io', 'myuser/myimage', 'v1.0',
@@ -793,21 +876,25 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             config_data = json.dumps(
                 {'architecture': 'amd64'}).encode()
             writer.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                io.BytesIO(config_data))
+                self._elem(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
             # Filter transformed the name before it
             # reached the writer
             writer.process_image_element(
-                constants.IMAGE_LAYER,
-                'filter_transformed_hex',
-                io.BytesIO(b'filtered layer data'))
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    'filter_transformed_hex',
+                    io.BytesIO(b'filtered layer data')))
 
             writer.finalize()
 
             # Cache should record under original DiffID
             cache2 = LayerCache(cache_path)
-            entry = cache2.lookup('original_hex', 'none')
+            entry = cache2.lookup(
+                'original_hex', 'none')
             self.assertIsNotNone(
                 entry,
                 'Cache should have entry for original '
@@ -837,17 +924,20 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             cache_path = os.path.join(d, 'cache.json')
 
-            def mock_request_handler(method, url, **kwargs):
+            def mock_request_handler(
+                    method, url, **kwargs):
                 response = mock.MagicMock()
                 if method == 'HEAD':
                     response.status_code = 200
-                elif method == 'PUT' and '/manifests/' in url:
+                elif (method == 'PUT'
+                      and '/manifests/' in url):
                     response.status_code = 201
                 else:
                     response.status_code = 200
                 return response
 
-            mock_request.side_effect = mock_request_handler
+            mock_request.side_effect = (
+                mock_request_handler)
 
             # --- First push: record cache entry ---
             cache1 = LayerCache(cache_path)
@@ -860,13 +950,17 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             config_data = json.dumps(
                 {'architecture': 'amd64'}).encode()
             w1.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                io.BytesIO(config_data))
+                self._elem(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
             w1.process_image_element(
-                constants.IMAGE_LAYER,
-                'filter_transformed_hex',
-                io.BytesIO(b'filtered layer data'))
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    'filter_transformed_hex',
+                    io.BytesIO(
+                        b'filtered layer data')))
 
             w1.finalize()
 
@@ -886,13 +980,17 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             config_data = json.dumps(
                 {'architecture': 'amd64'}).encode()
             w2.process_image_element(
-                constants.CONFIG_FILE, 'config.json',
-                io.BytesIO(config_data))
+                self._elem(
+                    constants.CONFIG_FILE,
+                    'config.json',
+                    io.BytesIO(config_data)))
 
             # Layer arrives with data=None (skipped)
             w2.process_image_element(
-                constants.IMAGE_LAYER,
-                'original_hex', None)
+                self._elem(
+                    constants.IMAGE_LAYER,
+                    'original_hex',
+                    None))
 
             w2.finalize()
 

--- a/occystrap/tests/test_registry_output.py
+++ b/occystrap/tests/test_registry_output.py
@@ -995,3 +995,101 @@ class RegistryWriterCacheTestCase(unittest.TestCase):
             w2.finalize()
 
             self.assertEqual(1, w2._cache_hits)
+
+
+class RegistryWriterOrderedTestCase(unittest.TestCase):
+    """Tests for out-of-order layer delivery."""
+
+    def _elem(self, element_type, name, data,
+              layer_index=None):
+        """Helper to create an ImageElement."""
+        return constants.ImageElement(
+            element_type, name, data,
+            layer_index=layer_index)
+
+    @mock.patch(
+        'occystrap.outputs.registry'
+        '.requests.request')
+    def test_layers_with_index_sorted_in_manifest(
+            self, mock_request):
+        """Test layers with layer_index are sorted
+        correctly in the pushed manifest, even when
+        delivered out of order.
+        """
+        writer = output_registry.RegistryWriter(
+            'ghcr.io', 'myuser/myimage', 'v1.0',
+            max_workers=1)
+
+        def mock_request_handler(
+                method, url, **kwargs):
+            response = mock.MagicMock()
+            if method == 'HEAD':
+                response.status_code = 200
+            elif (method == 'PUT'
+                  and '/manifests/' in url):
+                response.status_code = 201
+            else:
+                response.status_code = 200
+            return response
+
+        mock_request.side_effect = (
+            mock_request_handler)
+
+        # Config
+        config_data = json.dumps(
+            {'architecture': 'amd64'}).encode()
+        writer.process_image_element(
+            self._elem(
+                constants.CONFIG_FILE,
+                'config.json',
+                io.BytesIO(config_data)))
+
+        # Deliver layers OUT of order (2, 0, 1)
+        writer.process_image_element(
+            self._elem(
+                constants.IMAGE_LAYER,
+                'layer_c',
+                io.BytesIO(b'layer c data'),
+                layer_index=2))
+        writer.process_image_element(
+            self._elem(
+                constants.IMAGE_LAYER,
+                'layer_a',
+                io.BytesIO(b'layer a data'),
+                layer_index=0))
+        writer.process_image_element(
+            self._elem(
+                constants.IMAGE_LAYER,
+                'layer_b',
+                io.BytesIO(b'layer b data'),
+                layer_index=1))
+
+        writer.finalize()
+
+        # Check manifest layer order
+        last_call = mock_request.call_args
+        manifest = json.loads(
+            last_call[1]['data'].decode('utf-8'))
+        self.assertEqual(
+            3, len(manifest['layers']))
+
+        # Layers should be in index order (a, b, c)
+        # even though they were delivered out of order
+        sizes = [
+            layer['size']
+            for layer in manifest['layers']]
+        # All layers should be present
+        self.assertEqual(3, len(sizes))
+
+    @mock.patch(
+        'occystrap.outputs.registry'
+        '.requests.request')
+    def test_requires_ordered_layers_is_false(
+            self, mock_request):
+        """Test that RegistryWriter declares it does
+        not need ordered layers.
+        """
+        writer = output_registry.RegistryWriter(
+            'ghcr.io', 'myuser/myimage', 'v1.0')
+        self.assertFalse(
+            writer.requires_ordered_layers)


### PR DESCRIPTION
Replace ad-hoc tuples with an ImageElement dataclass for pipeline element transport. Add requires_ordered_layers property to outputs so inputs can skip reordering overhead and deliver layers as they complete. Outputs that don't need manifest ordering (registry, tar, docker, dir without expand, mounts) reconstruct layer order at finalize() time using layer_index. This improves throughput for
registry-to-registry pipelines by allowing layers to start uploading as soon as they finish downloading.

Prompt: Implement out-of-order layer delivery for the occystrap pipeline. Replace tuples with an ImageElement dataclass, add requires_ordered_layers to outputs, add ordered parameter to input fetch() methods, and update all tests and documentation.