### PR TITLE
Fix export-repo-config workflow permissions.

### DIFF
--- a/.github/workflows/export-repo-config.yml
+++ b/.github/workflows/export-repo-config.yml
@@ -1,7 +1,8 @@
 name: Export repository configuration
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The workflow needs to push a branch and create a pull request, which requires contents: write and pull-requests: write permissions. The workflow was failing with a 403 error because it only had contents: read.

Prompt: The repository configuration export github actions workflow lacks a permission.