### PR TITLE
Add dockerpush:// input via embedded registry.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,6 +21,7 @@ occystrap/
         __init__.py
         base.py          # ImageInput abstract base class
         docker.py        # Fetches images from local Docker daemon
+        dockerpush.py    # Fetches via embedded registry + Docker push
         registry.py      # Fetches images from Docker/OCI registries
         tarfile.py       # Reads from docker-save tarballs
     filters/             # Filter modules (transform/inspect pipeline)
@@ -45,6 +46,7 @@ occystrap/
         test_inspect.py
         test_registry_output.py
         test_layer_cache.py
+        test_dockerpush.py
         test_tarformat.py
 
 deploy/
@@ -87,6 +89,9 @@ All input sources inherit from the `ImageInput` abstract base class defined in
 Input source implementations:
 - `inputs/docker.py` - Fetches images from local Docker daemon via Unix socket,
   using hybrid streaming to minimize disk usage
+- `inputs/dockerpush.py` - Starts an embedded V2 registry on localhost and uses
+  Docker's push mechanism to receive layers in parallel; faster than docker.py
+  for multi-layer images
 - `inputs/registry.py` - Fetches images from Docker/OCI registries via HTTP API,
   with parallel layer downloads using ThreadPoolExecutor
 - `inputs/tarfile.py` - Reads from existing docker-save tarballs
@@ -187,6 +192,7 @@ occystrap process SOURCE DESTINATION [-f FILTER]...
 ```
 registry://[user:pass@]host/image:tag[?arch=X&os=Y&variant=Z]
 docker://image:tag[?socket=/path/to/socket]
+dockerpush://image:tag[?socket=/path/to/socket]
 tar:///path/to/file.tar
 ```
 
@@ -297,6 +303,53 @@ Key design considerations:
 - Temp files are cleaned up immediately after yielding each layer
 - Temp file location is configurable via `--temp-dir` CLI option
 - Graceful fallback when inspect data is unavailable or incorrect
+
+### Docker Push via Embedded Registry
+
+The `dockerpush` input (`inputs/dockerpush.py`) takes a fundamentally different
+approach to fetching images from a local Docker daemon. Instead of using the
+Docker Engine API's `/images/{name}/get` endpoint (which returns a single
+sequential tarball), it starts an embedded HTTP server implementing the Docker
+Registry V2 push-path API, then uses Docker's own push mechanism to transfer
+layers.
+
+```
+fetch() generator
+    └── Start ThreadingHTTPServer on 127.0.0.1:0 (ephemeral port)
+    └── Tag image for localhost push
+    └── POST /images/{name}/push (Docker pushes in parallel)
+    └── Wait for manifest event from registry handler
+    └── Parse manifest and config
+    └── For each layer:
+        ├── If fetch_callback returns False: yield with data=None
+        └── If True: read blob, decompress, yield ImageElement
+    └── Cleanup: untag, stop server, delete temp files
+```
+
+The embedded registry implements six V2 push-path endpoints:
+- `GET /v2/` - Version check
+- `HEAD /v2/{name}/blobs/{digest}` - Blob existence check
+- `POST /v2/{name}/blobs/uploads/` - Start upload
+- `PATCH /v2/{name}/blobs/uploads/{uuid}` - Receive chunks
+- `PUT /v2/{name}/blobs/uploads/{uuid}?digest=...` - Complete upload
+- `PUT /v2/{name}/manifests/{tag}` - Receive manifest
+
+Key design considerations:
+- Docker push uploads layers in parallel using the V2 protocol, providing
+  significantly better throughput than the sequential tarball export
+- Since Docker 1.3.2, `127.0.0.0/8` is implicitly trusted as insecure,
+  so no daemon.json changes or TLS certificates are needed
+- Blobs are stored as temp files during the push, then read and decompressed
+  when yielding elements
+- Thread-safe shared state (`_RegistryState`) coordinates between the HTTP
+  handler threads and the main fetch() thread
+- Cleanup is robust: untag, stop server, and delete temp files all happen
+  in nested try/finally blocks
+- When `--layer-cache` is used with a `registry://` output, the embedded
+  registry returns `200` for HEAD checks on cached layers, causing Docker
+  to skip their upload entirely. A persistent digest mapping file
+  (`{cache_path}.digests`) translates between Docker's compressed digests
+  and the DiffIDs used as cache keys
 
 ### Parallel Downloads
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ occystrap process SOURCE DESTINATION [-f FILTER]...
 
 - `registry://HOST/IMAGE:TAG` - Docker/OCI registry
 - `docker://IMAGE:TAG` - Local Docker daemon
+- `dockerpush://IMAGE:TAG` - Local Docker via push (fast, see below)
 - `tar:///path/to/file.tar` - Docker-save format tarball
 
 ### Output URI Schemes
@@ -293,6 +294,20 @@ occystrap docker-to-tarfile library/busybox latest busybox.tar
 ```
 occystrap process docker://library/busybox:latest tar://busybox.tar
 ```
+
+For faster local Docker image processing, use the `dockerpush://` input:
+```
+occystrap process dockerpush://library/busybox:latest tar://busybox.tar
+```
+
+The `dockerpush://` input starts an embedded Docker Registry V2 server on
+localhost and has Docker push the image to it. This is significantly faster
+than `docker://` for multi-layer images because Docker's push mechanism
+transfers layers individually and in parallel, whereas the Docker Engine API
+(`docker://`) exports the entire image as a single sequential tarball.
+
+Since Docker 1.3.2, the entire `127.0.0.0/8` range is implicitly trusted as
+insecure, so no daemon.json changes or TLS certificates are needed.
 
 For Podman:
 ```

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -156,6 +156,36 @@ docker://myimage:v1?socket=/run/podman/podman.sock
 docker://myimage:v1?socket=/run/user/1000/podman/podman.sock
 ```
 
+### dockerpush://
+
+Fetch images from the local Docker or Podman daemon using an embedded registry.
+This is faster than `docker://` for multi-layer images because Docker pushes
+layers in parallel using the Registry V2 protocol, rather than exporting the
+entire image as a single sequential tarball.
+
+```
+dockerpush://IMAGE:TAG[?socket=/path/to/socket]
+```
+
+**Query Options:**
+
+| Option | Description |
+|--------|-------------|
+| `socket=/path` | Custom daemon socket path |
+
+**Examples:**
+
+```bash
+# Docker daemon (default socket)
+dockerpush://myimage:v1
+
+# Podman (rootful)
+dockerpush://myimage:v1?socket=/run/podman/podman.sock
+
+# Compare speed with docker:// for multi-layer images
+dockerpush://python:3.11
+```
+
 ### tar://
 
 Read images from docker-save format tarballs.
@@ -433,6 +463,29 @@ occystrap --layer-cache /tmp/cache.json \
 
 The cache path can also be set via the `OCCYSTRAP_LAYER_CACHE`
 environment variable.
+
+### `dockerpush://` Integration
+
+When using `dockerpush://` as the input source with `--layer-cache`, occystrap
+enables a HEAD optimization that skips cached layers *before Docker even
+uploads them*. On the first run, all layers are transferred normally. On
+subsequent runs, the embedded registry returns `200` for HEAD checks on cached
+layers, causing Docker to skip the upload entirely. This means cached layers
+have zero local transfer overhead.
+
+A digest mapping file (`{cache_path}.digests`) is created alongside the
+cache to translate between Docker's compressed digests and the DiffIDs used
+as cache keys.
+
+```bash
+# First push: all layers transferred and cached
+occystrap --layer-cache /tmp/cache.json \
+    process dockerpush://app:v1 registry://myregistry/app:v1
+
+# Second push: Docker skips uploading shared layers entirely
+occystrap --layer-cache /tmp/cache.json \
+    process dockerpush://app:v2 registry://myregistry/app:v2
+```
 
 ### Pipeline Awareness
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ occystrap process SOURCE DESTINATION [-f FILTER]...
 Input URIs specify where to get images:
 - `registry://docker.io/library/busybox:latest` - Docker/OCI registry
 - `docker://myimage:v1` - Local Docker daemon
+- `dockerpush://myimage:v1` - Local Docker via push (fast)
 - `tar:///path/to/image.tar` - Existing tarball
 
 Output URIs specify where to write images:

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -185,8 +185,6 @@ after each push.
 - Only supports single-platform V2 manifests. If Docker pushes a manifest
   list (fat manifest) for a multi-arch image, parsing will fail. Use the
   `registry://` input for multi-arch images.
-- Reads each layer blob entirely into memory for decompression. For very
-  large layers (several GB), this may use significant memory.
 - The manifest wait timeout defaults to 300 seconds (`MANIFEST_TIMEOUT`
   constant in `dockerpush.py`). Very large images on slow systems may
   need this value increased.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -117,6 +117,79 @@ Key aspects:
 - For a 26GB image with in-order layers, disk usage is near zero
 - Temp file location is configurable via `--temp-dir` option
 
+### Docker Push Input
+
+Fetches images from local Docker or Podman daemons using an embedded registry.
+
+```
+dockerpush://IMAGE:TAG
+```
+
+**Why use `dockerpush://` instead of `docker://`?**
+
+The Docker Engine API (`/images/{name}/get`) exports images as a single
+sequential tarball. This is fundamentally slow for multi-layer images because
+it serializes all layers into one stream, with no opportunity for
+parallelization. The entire tarball must be read before the manifest becomes
+available.
+
+Docker's own `push` command, however, uses the Registry V2 HTTP API, which
+transfers layers individually and in parallel. The `dockerpush://` input
+exploits this by starting a minimal HTTP server on localhost that implements
+the V2 push-path endpoints. Docker pushes layers to this server just as it
+would push to any registry, but the received data feeds directly into the
+occystrap pipeline.
+
+Since Docker 1.3.2, the entire `127.0.0.0/8` range is implicitly trusted as
+insecure, so no daemon.json changes or TLS certificates are needed.
+
+**How it works:**
+
+```
+1. Start ThreadingHTTPServer on 127.0.0.1 (ephemeral port)
+2. Tag image for localhost push (POST /images/{name}/tag)
+3. Push image (POST /images/{name}/push)
+   - Docker uploads layers in parallel to embedded registry
+   - Server thread handles uploads, stores blobs as temp files
+4. Wait for manifest from Docker push
+5. Parse manifest + config to get layer DiffIDs
+6. Yield config element
+7. For each layer: read blob, decompress, yield ImageElement
+8. Cleanup: untag temp tag, stop server, delete temp files
+```
+
+**Threading model:**
+
+The embedded registry runs in a daemon thread handling Docker's parallel
+uploads. The main thread waits for the manifest to arrive, then reads the
+received blobs and yields pipeline elements. Shared state between threads
+is protected by a threading lock.
+
+**Layer cache integration:**
+
+When `--layer-cache` is used with a `registry://` output and a `dockerpush://`
+input, the embedded registry uses a HEAD optimization to skip cached layers
+*before Docker even uploads them*. On the first run, Docker uploads all layers
+normally and occystrap records a mapping between Docker's compressed digests
+and the uncompressed DiffIDs. On subsequent runs, the embedded registry returns
+`200` for HEAD checks on cached layers, causing Docker to skip the upload
+entirely. This means cached layers consume zero local transfer time.
+
+The digest mapping is stored alongside the layer cache as
+`{cache_path}.digests`. This file maps Docker's compressed layer digests to
+the uncompressed DiffIDs used as cache keys. It is updated automatically
+after each push.
+
+**When to use:**
+
+- Use `dockerpush://` when the source image is in a local Docker daemon
+  and the image has multiple layers. The speed advantage grows with the
+  number and size of layers.
+- Use `docker://` for single-layer images or when minimal overhead is
+  preferred (the embedded registry adds a small amount of setup time).
+- Use `dockerpush://` with `--layer-cache` for maximum performance in CI
+  workflows pushing multiple images that share base layers.
+
 ### Tarball Input
 
 Reads images from existing docker-save format tarballs.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -180,6 +180,17 @@ The digest mapping is stored alongside the layer cache as
 the uncompressed DiffIDs used as cache keys. It is updated automatically
 after each push.
 
+**Limitations:**
+
+- Only supports single-platform V2 manifests. If Docker pushes a manifest
+  list (fat manifest) for a multi-arch image, parsing will fail. Use the
+  `registry://` input for multi-arch images.
+- Reads each layer blob entirely into memory for decompression. For very
+  large layers (several GB), this may use significant memory.
+- The manifest wait timeout defaults to 300 seconds (`MANIFEST_TIMEOUT`
+  constant in `dockerpush.py`). Very large images on slow systems may
+  need this value increased.
+
 **When to use:**
 
 - Use `dockerpush://` when the source image is in a local Docker daemon

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -117,6 +117,11 @@ occystrap --username destuser --password desttoken \
 occystrap --username myuser --password mytoken \
     process docker://myapp:v1 \
     registry://ghcr.io/myorg/myapp:v1
+
+# Copy from local Docker to registry (faster for multi-layer images)
+occystrap --username myuser --password mytoken \
+    process dockerpush://myapp:v1 \
+    registry://ghcr.io/myorg/myapp:v1
 ```
 
 ## Multi-Architecture Images
@@ -286,6 +291,25 @@ for image in python:3.11 node:18 postgres:15; do
             "tar://$CACHE_DIR/$name.tar" -f normalize-timestamps
     fi
 done
+```
+
+### Fast Local-to-Registry Push with Layer Cache
+
+```bash
+#!/bin/bash
+# ci-push.sh - Push locally-built images to registry with layer cache
+# Uses dockerpush:// for fast transfer from local Docker and
+# --layer-cache to skip re-processing shared base layers.
+
+CACHE="/tmp/occystrap-cache.json"
+
+for image in app-web app-api app-worker; do
+    occystrap --layer-cache "$CACHE" \
+        process "dockerpush://$image:latest" \
+        "registry://myregistry.example.com/$image:latest" \
+        -f normalize-timestamps
+done
+# Second and third images skip uploading shared base layers
 ```
 
 ### Verify Image Contents

--- a/occystrap/inputs/base.py
+++ b/occystrap/inputs/base.py
@@ -1,6 +1,11 @@
 from abc import ABC, abstractmethod
 
 
+def always_fetch(digest):
+    """Default fetch callback that fetches all layers."""
+    return True
+
+
 class ImageInput(ABC):
     """Abstract base class for image input sources.
 

--- a/occystrap/inputs/docker.py
+++ b/occystrap/inputs/docker.py
@@ -70,7 +70,7 @@ import tempfile
 import requests_unixsocket
 
 from occystrap import constants
-from occystrap.inputs.base import ImageInput
+from occystrap.inputs.base import ImageInput, always_fetch
 
 COPY_BUFSIZE = 1024 * 1024  # 1MB chunks for streaming copies
 
@@ -79,10 +79,6 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 DEFAULT_SOCKET_PATH = '/var/run/docker.sock'
-
-
-def always_fetch(digest):
-    return True
 
 
 class Image(ImageInput):

--- a/occystrap/inputs/dockerpush.py
+++ b/occystrap/inputs/dockerpush.py
@@ -46,6 +46,11 @@ DEFAULT_SOCKET_PATH = '/var/run/docker.sock'
 
 COPY_BUFSIZE = 1024 * 1024  # 1MB chunks
 
+# Seconds to wait for Docker to push the manifest
+# after the push API call completes. Large images on
+# slow systems may need more time.
+MANIFEST_TIMEOUT = 300
+
 
 def always_fetch(digest):
     return True
@@ -101,12 +106,41 @@ class EmbeddedRegistryHandler(
         LOG.debug('Registry: %s' % (format % args))
 
     def _read_body(self):
-        """Read the full request body."""
+        """Read the full request body.
+
+        Handles both Content-Length and chunked
+        Transfer-Encoding. Falls back to empty body
+        if neither is present.
+        """
+        transfer_enc = self.headers.get(
+            'Transfer-Encoding', '').lower()
+        if 'chunked' in transfer_enc:
+            return self._read_chunked_body()
+
         length = int(
             self.headers.get('Content-Length', 0))
         if length > 0:
             return self.rfile.read(length)
         return b''
+
+    def _read_chunked_body(self):
+        """Read a chunked transfer-encoded body."""
+        body = io.BytesIO()
+        while True:
+            line = self.rfile.readline()
+            # Chunk size is hex, may have extensions
+            # after a semicolon
+            chunk_size = int(
+                line.strip().split(b';')[0], 16)
+            if chunk_size == 0:
+                # Read trailing CRLF after final chunk
+                self.rfile.readline()
+                break
+            body.write(
+                self.rfile.read(chunk_size))
+            # Read trailing CRLF after chunk data
+            self.rfile.readline()
+        return body.getvalue()
 
     def _parse_path(self):
         """Parse the request path and query string."""
@@ -218,20 +252,22 @@ class EmbeddedRegistryHandler(
 
         upload_uuid = parts[1].strip('/')
 
+        # Read body outside the lock to avoid
+        # blocking other handler threads during I/O
+        data = self._read_body()
+
         with self.state.lock:
             upload = self.state.uploads.get(upload_uuid)
+            if not upload:
+                self.send_response(404)
+                self.end_headers()
+                return
 
-        if not upload:
-            self.send_response(404)
-            self.end_headers()
-            return
-
-        # Read and write data
-        data = self._read_body()
-        with open(upload['path'], 'ab') as f:
-            f.write(data)
-
-        with self.state.lock:
+            # Write and update offset under the lock
+            # so _handle_blob_put cannot delete the
+            # upload between our lookup and write
+            with open(upload['path'], 'ab') as f:
+                f.write(data)
             upload['offset'] += len(data)
             new_offset = upload['offset']
 
@@ -386,13 +422,23 @@ class EmbeddedRegistryHandler(
 
 
 class Image(ImageInput):
-    """Fetch images from Docker/Podman by pushing to an embedded
-    registry.
+    """Fetch images from Docker/Podman by pushing to an
+    embedded registry.
 
     Instead of using Docker's /images/{name}/get API (which
     returns a single sequential tarball), this input starts a
     minimal HTTP server on localhost and uses Docker's push
     mechanism to transfer layers in parallel.
+
+    Limitations:
+    - Only supports single-platform V2 manifests. If
+      Docker pushes a manifest list (fat manifest) for a
+      multi-arch image, parsing will fail. Use the
+      registry:// input for multi-arch images.
+    - Reads each layer blob entirely into memory for
+      decompression. For very large layers (several GB),
+      this may use significant memory. Future improvement:
+      use streaming decompression.
     """
 
     def __init__(self, image, tag='latest',
@@ -558,7 +604,7 @@ class Image(ImageInput):
         """
         if self.layer_cache is None:
             return None
-        return self.layer_cache._path + '.digests'
+        return self.layer_cache.path + '.digests'
 
     def _load_digest_mapping(self):
         """Load the Docker compressed digest -> DiffID
@@ -636,6 +682,16 @@ class Image(ImageInput):
         checks the layer cache to see which DiffIDs are
         cached.
 
+        The fetch_callback follows the convention from
+        ImageInput.fetch(): it returns True if the layer
+        should be fetched, False if it can be skipped.
+        For RegistryWriter, False means the remote
+        registry already has the blob. This method is
+        called before the push starts, but fetch_callback
+        is already usable at that point because it only
+        queries the layer cache and remote registry
+        (both initialized before fetch() is called).
+
         Returns:
             Tuple of (skip_digests_set,
                       digest_to_diffid_mapping).
@@ -708,10 +764,12 @@ class Image(ImageInput):
 
                 # Wait for manifest
                 if not state.manifest_event.wait(
-                        timeout=300):
+                        timeout=MANIFEST_TIMEOUT):
                     raise Exception(
                         'Timed out waiting for'
-                        ' manifest from Docker push')
+                        ' manifest from Docker push'
+                        ' (timeout=%ds)'
+                        % MANIFEST_TIMEOUT)
 
                 # Parse manifest
                 manifest = json.loads(
@@ -810,24 +868,26 @@ class Image(ImageInput):
                     # If Docker skipped upload (blob
                     # not in state.blobs), the layer
                     # was cached and HEAD returned 200
-                    if compressed_hex \
-                            not in state.blobs:
-                        if compressed_hex \
-                                in state.skip_digests:
+                    blob_missing = (
+                        compressed_hex not in state.blobs)
+                    was_skipped = (
+                        compressed_hex
+                        in state.skip_digests)
+
+                    if blob_missing:
+                        if was_skipped:
                             LOG.info(
                                 '[%d/%d] Skipping'
                                 ' layer %s...'
-                                ' (cached, HEAD'
-                                ' skip)'
+                                ' (cached, HEAD skip)'
                                 % (layer_idx + 1,
                                    len(layers),
                                    diff_id[:12]))
-                            yield constants\
-                                .ImageElement(
-                                    constants
-                                    .IMAGE_LAYER,
-                                    diff_id, None,
-                                    layer_index=idx)
+                            elem = constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                diff_id, None,
+                                layer_index=idx)
+                            yield elem
                             layers_skipped += 1
                             continue
                         raise Exception(
@@ -838,29 +898,34 @@ class Image(ImageInput):
                     blob_path = state.blobs[
                         compressed_hex]
 
-                    # Detect and decompress
+                    # Detect and decompress.
+                    # NOTE: reads entire blob into
+                    # memory. Future improvement:
+                    # use streaming decompression
+                    # for large layers.
                     media_type = layer_meta.get(
                         'mediaType')
-                    comp_type = compression\
+                    comp_type = (
+                        compression
                         .detect_compression_from_media_type(
-                            media_type)
-                    if comp_type == constants\
-                            .COMPRESSION_UNKNOWN:
+                            media_type))
+                    unknown = constants.COMPRESSION_UNKNOWN
+                    if comp_type == unknown:
                         with open(
                                 blob_path, 'rb') as f:
-                            comp_type = compression\
-                                .detect_compression(f)
+                            comp_type = (
+                                compression
+                                .detect_compression(f))
 
                     with open(blob_path, 'rb') as f:
                         blob_data = f.read()
 
-                    if comp_type in (
-                            constants.COMPRESSION_GZIP,
-                            constants
-                            .COMPRESSION_ZSTD):
-                        decompressed = compression\
-                            .decompress_data(
-                                blob_data, comp_type)
+                    GZIP = constants.COMPRESSION_GZIP
+                    ZSTD = constants.COMPRESSION_ZSTD
+                    if comp_type in (GZIP, ZSTD):
+                        decompressed = (
+                            compression.decompress_data(
+                                blob_data, comp_type))
                     else:
                         decompressed = blob_data
 

--- a/occystrap/inputs/dockerpush.py
+++ b/occystrap/inputs/dockerpush.py
@@ -435,10 +435,9 @@ class Image(ImageInput):
       Docker pushes a manifest list (fat manifest) for a
       multi-arch image, parsing will fail. Use the
       registry:// input for multi-arch images.
-    - Reads each layer blob entirely into memory for
-      decompression. For very large layers (several GB),
-      this may use significant memory. Future improvement:
-      use streaming decompression.
+    - Layer decompression uses streaming with constant
+      memory (1MB buffer), but blob data is received to
+      temp files on disk during the push.
     """
 
     def __init__(self, image, tag='latest',
@@ -898,11 +897,7 @@ class Image(ImageInput):
                     blob_path = state.blobs[
                         compressed_hex]
 
-                    # Detect and decompress.
-                    # NOTE: reads entire blob into
-                    # memory. Future improvement:
-                    # use streaming decompression
-                    # for large layers.
+                    # Detect compression type
                     media_type = layer_meta.get(
                         'mediaType')
                     comp_type = (
@@ -917,17 +912,49 @@ class Image(ImageInput):
                                 compression
                                 .detect_compression(f))
 
-                    with open(blob_path, 'rb') as f:
-                        blob_data = f.read()
+                    # Treat unknown as passthrough
+                    if comp_type == unknown:
+                        comp_type = (
+                            constants.COMPRESSION_NONE)
 
-                    GZIP = constants.COMPRESSION_GZIP
-                    ZSTD = constants.COMPRESSION_ZSTD
-                    if comp_type in (GZIP, ZSTD):
-                        decompressed = (
-                            compression.decompress_data(
-                                blob_data, comp_type))
-                    else:
-                        decompressed = blob_data
+                    # Stream decompress to temp file
+                    # (constant memory regardless of
+                    # layer size)
+                    d = compression.StreamingDecompressor(
+                        comp_type)
+                    tf = tempfile.NamedTemporaryFile(
+                        delete=False,
+                        dir=self.temp_dir)
+                    compressed_size = 0
+                    try:
+                        with open(
+                                blob_path, 'rb') as f:
+                            while True:
+                                chunk = f.read(
+                                    COPY_BUFSIZE)
+                                if not chunk:
+                                    break
+                                compressed_size += (
+                                    len(chunk))
+                                tf.write(
+                                    d.decompress(chunk))
+                        remaining = d.flush()
+                        if remaining:
+                            tf.write(remaining)
+                        decompressed_size = tf.tell()
+                        tf.close()
+                    except BaseException:
+                        tf.close()
+                        os.unlink(tf.name)
+                        raise
+
+                    # Delete compressed blob now that
+                    # we have the decompressed copy
+                    try:
+                        os.unlink(blob_path)
+                    except OSError:
+                        pass
+                    del state.blobs[compressed_hex]
 
                     LOG.info(
                         '[%d/%d] Layer %s...'
@@ -936,14 +963,21 @@ class Image(ImageInput):
                         % (layer_idx + 1,
                            len(layers),
                            diff_id[:12],
-                           len(blob_data),
-                           len(decompressed)))
+                           compressed_size,
+                           decompressed_size))
 
-                    yield constants.ImageElement(
-                        constants.IMAGE_LAYER,
-                        diff_id,
-                        io.BytesIO(decompressed),
-                        layer_index=idx)
+                    try:
+                        with open(
+                                tf.name, 'rb') as fh:
+                            yield constants.ImageElement(
+                                constants.IMAGE_LAYER,
+                                diff_id, fh,
+                                layer_index=idx)
+                    finally:
+                        try:
+                            os.unlink(tf.name)
+                        except OSError:
+                            pass
                     layers_fetched += 1
 
                 # Save updated digest mapping

--- a/occystrap/inputs/dockerpush.py
+++ b/occystrap/inputs/dockerpush.py
@@ -1,0 +1,917 @@
+# Fetch images from the local Docker or Podman daemon by pushing
+# to an embedded registry. This avoids the Docker Engine API
+# limitation where /images/{name}/get returns a single sequential
+# tarball that cannot be parallelized.
+#
+# Instead, we start a minimal HTTP server implementing the Docker
+# Registry V2 push-path API on localhost, then use Docker's own
+# push mechanism (POST /images/{name}/push) to send layers to it.
+# Docker push uploads layers individually and in parallel using
+# the Registry V2 protocol, providing significantly better
+# throughput for multi-layer images.
+#
+# Since Docker 1.3.2, the entire 127.0.0.0/8 range is implicitly
+# trusted as insecure, so no daemon.json changes or TLS
+# certificates are needed.
+#
+# Docker Engine API documentation:
+# https://docs.docker.com/engine/api/
+#
+# Docker Registry HTTP API V2:
+# https://distribution.github.io/distribution/spec/api/
+
+import base64
+import hashlib
+import http.server
+import io
+import json
+import logging
+import os
+import tempfile
+import threading
+import uuid
+from urllib.parse import urlparse, parse_qs
+
+import requests_unixsocket
+
+from occystrap import compression
+from occystrap import constants
+from occystrap.inputs.base import ImageInput
+
+
+LOG = logging.getLogger(__name__)
+LOG.setLevel(logging.INFO)
+
+DEFAULT_SOCKET_PATH = '/var/run/docker.sock'
+
+COPY_BUFSIZE = 1024 * 1024  # 1MB chunks
+
+
+def always_fetch(digest):
+    return True
+
+
+class _RegistryState:
+    """Shared state between the embedded registry HTTP handler
+    threads and the main fetch() thread.
+
+    All mutations to uploads, blobs, and manifest_data must
+    be protected by the lock.
+    """
+
+    def __init__(self, temp_dir=None):
+        self.temp_dir = temp_dir
+        # In-progress uploads: uuid -> {path, file, offset}
+        self.uploads = {}
+        # Completed blobs: digest_hex -> temp file path
+        self.blobs = {}
+        # Received manifest
+        self.manifest_data = None
+        self.manifest_event = threading.Event()
+        self.lock = threading.Lock()
+        # Compressed digest hexes that Docker should skip
+        # (populated from cache + digest mapping before
+        # push). When non-empty, HEAD returns 200 for
+        # these digests, causing Docker to skip upload.
+        self.skip_digests = set()
+
+
+class EmbeddedRegistryHandler(
+        http.server.BaseHTTPRequestHandler):
+    """HTTP handler implementing the Docker Registry V2
+    push-path endpoints.
+
+    Docker's push command uses these endpoints in order:
+    1. GET /v2/ - Version check
+    2. HEAD /v2/{name}/blobs/{digest} - Check blob existence
+    3. POST /v2/{name}/blobs/uploads/ - Start upload
+    4. PATCH /v2/{name}/blobs/uploads/{uuid} - Receive chunks
+    5. PUT /v2/{name}/blobs/uploads/{uuid}?digest=... - Complete
+    6. PUT /v2/{name}/manifests/{tag} - Receive manifest
+
+    All received blobs are stored as temp files. The manifest
+    is stored in memory.
+    """
+
+    @property
+    def state(self):
+        return self.server.registry_state
+
+    def log_message(self, format, *args):
+        LOG.debug('Registry: %s' % (format % args))
+
+    def _read_body(self):
+        """Read the full request body."""
+        length = int(
+            self.headers.get('Content-Length', 0))
+        if length > 0:
+            return self.rfile.read(length)
+        return b''
+
+    def _parse_path(self):
+        """Parse the request path and query string."""
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+        return parsed.path, params
+
+    def do_GET(self):
+        """Handle GET /v2/ version check."""
+        path, _ = self._parse_path()
+        if path == '/v2/' or path == '/v2':
+            self.send_response(200)
+            self.send_header(
+                'Docker-Distribution-API-Version',
+                'registry/2.0')
+            self.send_header(
+                'Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_HEAD(self):
+        """Handle HEAD /v2/{name}/blobs/{digest}.
+
+        Returns 200 for digests in skip_digests (cached
+        layers), causing Docker to skip the upload.
+        Returns 404 otherwise to force Docker to upload.
+        """
+        path, _ = self._parse_path()
+
+        # Extract digest from path
+        # Format: /v2/{name}/blobs/sha256:{hex}
+        if '/blobs/sha256:' in path:
+            digest_hex = path.split(
+                '/blobs/sha256:')[1]
+            if digest_hex in \
+                    self.state.skip_digests:
+                self.send_response(200)
+                self.send_header(
+                    'Docker-Content-Digest',
+                    'sha256:%s' % digest_hex)
+                self.send_header(
+                    'Content-Length', '0')
+                self.end_headers()
+                return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        """Handle POST /v2/{name}/blobs/uploads/.
+
+        Start a new blob upload. Returns a UUID and Location
+        header for subsequent PATCH/PUT requests.
+        """
+        path, _ = self._parse_path()
+
+        if '/blobs/uploads' not in path:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        upload_uuid = str(uuid.uuid4())
+
+        # Create temp file for this upload
+        tf = tempfile.NamedTemporaryFile(
+            delete=False, dir=self.state.temp_dir)
+        tf_path = tf.name
+        tf.close()
+
+        with self.state.lock:
+            self.state.uploads[upload_uuid] = {
+                'path': tf_path,
+                'offset': 0,
+            }
+
+        # Extract the repository name from the path
+        # Path format: /v2/{name}/blobs/uploads/
+        parts = path.split('/blobs/uploads')
+        repo_path = parts[0] if parts else '/v2/_'
+
+        location = (
+            '%s/blobs/uploads/%s'
+            % (repo_path, upload_uuid))
+
+        self.send_response(202)
+        self.send_header('Location', location)
+        self.send_header(
+            'Docker-Upload-UUID', upload_uuid)
+        self.send_header('Range', '0-0')
+        self.send_header('Content-Length', '0')
+        self.end_headers()
+
+    def do_PATCH(self):
+        """Handle PATCH /v2/{name}/blobs/uploads/{uuid}.
+
+        Receive blob data chunks and append to temp file.
+        """
+        path, _ = self._parse_path()
+
+        # Extract UUID from path
+        parts = path.split('/blobs/uploads/')
+        if len(parts) < 2:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        upload_uuid = parts[1].strip('/')
+
+        with self.state.lock:
+            upload = self.state.uploads.get(upload_uuid)
+
+        if not upload:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        # Read and write data
+        data = self._read_body()
+        with open(upload['path'], 'ab') as f:
+            f.write(data)
+
+        with self.state.lock:
+            upload['offset'] += len(data)
+            new_offset = upload['offset']
+
+        # Build location for response
+        repo_path = path.split(
+            '/blobs/uploads/')[0]
+        location = (
+            '%s/blobs/uploads/%s'
+            % (repo_path, upload_uuid))
+
+        self.send_response(202)
+        self.send_header('Location', location)
+        self.send_header(
+            'Docker-Upload-UUID', upload_uuid)
+        self.send_header(
+            'Range', '0-%d' % (new_offset - 1))
+        self.send_header('Content-Length', '0')
+        self.end_headers()
+
+    def do_PUT(self):
+        """Handle PUT for blob completion and manifest upload.
+
+        Two cases:
+        - PUT /v2/{name}/blobs/uploads/{uuid}?digest=...
+          Complete a blob upload with digest verification.
+        - PUT /v2/{name}/manifests/{tag}
+          Receive the image manifest.
+        """
+        path, params = self._parse_path()
+
+        if '/manifests/' in path:
+            self._handle_manifest_put()
+            return
+
+        if '/blobs/uploads/' not in path:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        self._handle_blob_put(path, params)
+
+    def _handle_blob_put(self, path, params):
+        """Complete a blob upload with digest verification."""
+        # Extract UUID
+        parts = path.split('/blobs/uploads/')
+        if len(parts) < 2:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        upload_uuid = parts[1].strip('/')
+
+        with self.state.lock:
+            upload = self.state.uploads.get(upload_uuid)
+
+        if not upload:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        # Read any remaining body data (monolithic upload
+        # sends all data in the PUT)
+        data = self._read_body()
+        if data:
+            with open(upload['path'], 'ab') as f:
+                f.write(data)
+
+        # Get expected digest from query params
+        digest_list = params.get('digest', [])
+        if not digest_list:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        expected_digest = digest_list[0]
+        if expected_digest.startswith('sha256:'):
+            expected_hex = expected_digest[7:]
+        else:
+            expected_hex = expected_digest
+
+        # Verify SHA256
+        h = hashlib.sha256()
+        with open(upload['path'], 'rb') as f:
+            while True:
+                chunk = f.read(COPY_BUFSIZE)
+                if not chunk:
+                    break
+                h.update(chunk)
+
+        actual_hex = h.hexdigest()
+        if actual_hex != expected_hex:
+            LOG.error(
+                'Blob digest mismatch: expected %s,'
+                ' got %s' % (expected_hex, actual_hex))
+            # Clean up temp file
+            try:
+                os.unlink(upload['path'])
+            except OSError:
+                pass
+            with self.state.lock:
+                del self.state.uploads[upload_uuid]
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        # Move blob to completed state
+        blob_path = upload['path']
+        with self.state.lock:
+            self.state.blobs[expected_hex] = blob_path
+            del self.state.uploads[upload_uuid]
+
+        blob_size = os.path.getsize(blob_path)
+        LOG.info(
+            'Received blob sha256:%s... (%d bytes)'
+            % (expected_hex[:12], blob_size))
+
+        self.send_response(201)
+        self.send_header(
+            'Docker-Content-Digest',
+            'sha256:%s' % expected_hex)
+        self.send_header('Content-Length', '0')
+        self.send_header(
+            'Location',
+            '/v2/_/blobs/sha256:%s' % expected_hex)
+        self.end_headers()
+
+    def _handle_manifest_put(self):
+        """Receive and store the image manifest."""
+        data = self._read_body()
+
+        # Compute digest of manifest
+        h = hashlib.sha256()
+        h.update(data)
+        manifest_digest = h.hexdigest()
+
+        with self.state.lock:
+            self.state.manifest_data = data
+
+        LOG.info(
+            'Received manifest (%d bytes, sha256:%s...)'
+            % (len(data), manifest_digest[:12]))
+
+        # Signal that the push is complete
+        self.state.manifest_event.set()
+
+        self.send_response(201)
+        self.send_header(
+            'Docker-Content-Digest',
+            'sha256:%s' % manifest_digest)
+        self.send_header('Content-Length', '0')
+        self.end_headers()
+
+
+class Image(ImageInput):
+    """Fetch images from Docker/Podman by pushing to an embedded
+    registry.
+
+    Instead of using Docker's /images/{name}/get API (which
+    returns a single sequential tarball), this input starts a
+    minimal HTTP server on localhost and uses Docker's push
+    mechanism to transfer layers in parallel.
+    """
+
+    def __init__(self, image, tag='latest',
+                 socket_path=DEFAULT_SOCKET_PATH,
+                 temp_dir=None, layer_cache=None,
+                 filters_hash='none'):
+        self._image = image
+        self._tag = tag
+        self.socket_path = socket_path
+        self.temp_dir = temp_dir
+        self.layer_cache = layer_cache
+        self.filters_hash = filters_hash
+        self._session = None
+
+    @property
+    def image(self):
+        """Return the image name."""
+        return self._image
+
+    @property
+    def tag(self):
+        """Return the image tag."""
+        return self._tag
+
+    def _get_session(self):
+        if self._session is None:
+            self._session = \
+                requests_unixsocket.Session()
+        return self._session
+
+    def _socket_url(self, path):
+        # requests_unixsocket uses http+unix:// with
+        # URL-encoded socket path
+        encoded_socket = self.socket_path.replace(
+            '/', '%2F')
+        return 'http+unix://%s%s' % (
+            encoded_socket, path)
+
+    def _request(self, method, path, stream=False,
+                 headers=None, data=None):
+        session = self._get_session()
+        url = self._socket_url(path)
+        LOG.debug(
+            'Docker API request: %s %s'
+            % (method, path))
+        r = session.request(
+            method, url, stream=stream,
+            headers=headers, data=data)
+        return r
+
+    def _get_image_reference(self):
+        return '%s:%s' % (self.image, self.tag)
+
+    def _tag_image(self, repo, tag):
+        """Tag an image for pushing to localhost registry.
+
+        Uses POST /images/{name}/tag to create a new tag
+        pointing to the same image.
+        """
+        ref = self._get_image_reference()
+        path = '/images/%s/tag?repo=%s&tag=%s' % (
+            ref, repo, tag)
+        r = self._request('POST', path)
+        if r.status_code == 404:
+            raise Exception(
+                'Image not found: %s' % ref)
+        if r.status_code not in (200, 201):
+            raise Exception(
+                'Failed to tag image: %d %s'
+                % (r.status_code, r.text))
+        LOG.info('Tagged %s as %s:%s' % (ref, repo, tag))
+
+    def _push_image(self, repo, tag):
+        """Push an image to the embedded registry.
+
+        Uses POST /images/{name}/push with streaming response.
+        Consumes the stream and checks for errors.
+        """
+        push_ref = '%s:%s' % (repo, tag)
+        path = '/images/%s/push' % push_ref
+        auth_header = base64.b64encode(
+            b'{}').decode('ascii')
+        r = self._request(
+            'POST', path, stream=True,
+            headers={
+                'X-Registry-Auth': auth_header
+            })
+
+        if r.status_code != 200:
+            raise Exception(
+                'Push request failed: %d %s'
+                % (r.status_code, r.text))
+
+        LOG.info('Push started for %s' % push_ref)
+
+        # Consume streaming response and check for
+        # errors. Docker sends one JSON object per line.
+        for line in r.iter_lines():
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            if 'error' in event:
+                raise Exception(
+                    'Docker push failed: %s'
+                    % event['error'])
+
+            status = event.get('status', '')
+            if status:
+                LOG.debug('Push: %s' % status)
+
+        LOG.info('Push completed for %s' % push_ref)
+
+    def _untag_image(self, repo, tag):
+        """Remove a temporary tag from the Docker daemon.
+
+        Uses DELETE /images/{name}?noprune=true to remove
+        only the tag without deleting underlying layers.
+        """
+        ref = '%s:%s' % (repo, tag)
+        path = '/images/%s?noprune=true' % ref
+        r = self._request('DELETE', path)
+        if r.status_code in (200, 404):
+            LOG.info('Untagged %s' % ref)
+        else:
+            LOG.warning(
+                'Failed to untag %s: %d %s'
+                % (ref, r.status_code, r.text))
+
+    def _start_server(self, state):
+        """Start the embedded registry HTTP server.
+
+        Binds to 127.0.0.1:0 (ephemeral port) and runs
+        in a daemon thread.
+        """
+        server = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', 0),
+            EmbeddedRegistryHandler)
+        server.registry_state = state
+        thread = threading.Thread(
+            target=server.serve_forever,
+            daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        LOG.info(
+            'Embedded registry listening on'
+            ' 127.0.0.1:%d' % port)
+        return server
+
+    def _stop_server(self, server):
+        """Stop the embedded registry HTTP server."""
+        server.shutdown()
+        LOG.info('Embedded registry stopped')
+
+    def _digest_mapping_path(self):
+        """Return the path for the digest mapping file.
+
+        Stored alongside the layer cache as
+        {cache_path}.digests.
+        """
+        if self.layer_cache is None:
+            return None
+        return self.layer_cache._path + '.digests'
+
+    def _load_digest_mapping(self):
+        """Load the Docker compressed digest -> DiffID
+        mapping from disk.
+
+        Returns:
+            Dict mapping docker_compressed_hex to
+            diffid_hex, or empty dict if not found.
+        """
+        path = self._digest_mapping_path()
+        if path is None or not os.path.exists(path):
+            return {}
+        try:
+            with open(path, 'r') as f:
+                data = json.load(f)
+            if data.get('version') == 1:
+                LOG.info(
+                    'Loaded digest mapping with'
+                    ' %d entries from %s'
+                    % (len(data.get('mappings', {})),
+                       path))
+                return data.get('mappings', {})
+        except (json.JSONDecodeError, OSError) as e:
+            LOG.warning(
+                'Could not load digest mapping'
+                ' %s: %s' % (path, e))
+        return {}
+
+    def _save_digest_mapping(self, mappings):
+        """Save the Docker compressed digest -> DiffID
+        mapping to disk.
+
+        Args:
+            mappings: Dict mapping
+                docker_compressed_hex to diffid_hex.
+        """
+        path = self._digest_mapping_path()
+        if path is None:
+            return
+
+        data = {
+            'version': 1,
+            'mappings': mappings,
+        }
+
+        cache_dir = os.path.dirname(path)
+        if cache_dir:
+            os.makedirs(cache_dir, exist_ok=True)
+
+        try:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=cache_dir or '.', suffix='.tmp')
+            try:
+                with os.fdopen(fd, 'w') as f:
+                    json.dump(data, f, indent=2)
+                os.replace(tmp_path, path)
+                LOG.info(
+                    'Saved digest mapping with'
+                    ' %d entries to %s'
+                    % (len(mappings), path))
+            except BaseException:
+                os.unlink(tmp_path)
+                raise
+        except OSError as e:
+            LOG.warning(
+                'Could not save digest mapping:'
+                ' %s' % e)
+
+    def _build_skip_digests(self, fetch_callback):
+        """Build the set of Docker compressed digests
+        that should be skipped.
+
+        Uses the digest mapping file to translate between
+        Docker's compressed digests and DiffIDs, then
+        checks the layer cache to see which DiffIDs are
+        cached.
+
+        Returns:
+            Tuple of (skip_digests_set,
+                      digest_to_diffid_mapping).
+        """
+        if self.layer_cache is None:
+            return set(), {}
+
+        mapping = self._load_digest_mapping()
+        if not mapping:
+            return set(), mapping
+
+        skip = set()
+        for docker_hex, diffid_hex in mapping.items():
+            # Check if this layer is cached
+            entry = self.layer_cache.lookup(
+                diffid_hex, self.filters_hash)
+            if entry is not None:
+                # Also check fetch_callback to ensure
+                # the output agrees this layer can be
+                # skipped
+                if not fetch_callback(diffid_hex):
+                    skip.add(docker_hex)
+                    LOG.debug(
+                        'Will skip blob %s...'
+                        ' (cached as %s...)'
+                        % (docker_hex[:12],
+                           diffid_hex[:12]))
+
+        if skip:
+            LOG.info(
+                'Skipping %d cached layer(s) via'
+                ' HEAD optimization' % len(skip))
+
+        return skip, mapping
+
+    def fetch(self, fetch_callback=always_fetch,
+              ordered=True):
+        """Fetch image layers by pushing to an embedded
+        registry.
+
+        Starts a minimal V2 registry on localhost, uses
+        Docker's push API to transfer layers, then yields
+        ImageElements from the received data.
+        """
+        ref = self._get_image_reference()
+        LOG.info(
+            'Fetching image %s via dockerpush from'
+            ' daemon at %s' % (ref, self.socket_path))
+
+        state = _RegistryState(temp_dir=self.temp_dir)
+
+        # Build skip set from cache before starting
+        skip_set, digest_mapping = \
+            self._build_skip_digests(fetch_callback)
+        state.skip_digests = skip_set
+
+        server = self._start_server(state)
+        port = server.server_address[1]
+        push_repo = 'localhost:%d/%s' % (
+            port, self._image)
+
+        try:
+            # Tag image for localhost push
+            self._tag_image(push_repo, self._tag)
+
+            try:
+                # Push to embedded registry
+                self._push_image(
+                    push_repo, self._tag)
+
+                # Wait for manifest
+                if not state.manifest_event.wait(
+                        timeout=300):
+                    raise Exception(
+                        'Timed out waiting for'
+                        ' manifest from Docker push')
+
+                # Parse manifest
+                manifest = json.loads(
+                    state.manifest_data)
+                LOG.info(
+                    'Manifest received: %d layers'
+                    % len(manifest.get('layers', [])))
+
+                # Get config blob
+                config_digest = manifest[
+                    'config']['digest']
+                config_hex = config_digest.split(
+                    ':')[1]
+
+                if config_hex not in state.blobs:
+                    raise Exception(
+                        'Config blob %s not received'
+                        % config_digest)
+
+                with open(
+                        state.blobs[config_hex],
+                        'rb') as f:
+                    config_data = f.read()
+
+                config_filename = (
+                    '%s.json' % config_hex)
+                LOG.info(
+                    'Config: %s (%d bytes)'
+                    % (config_filename,
+                       len(config_data)))
+
+                yield constants.ImageElement(
+                    constants.CONFIG_FILE,
+                    config_filename,
+                    io.BytesIO(config_data))
+
+                # Parse config for DiffIDs (the
+                # uncompressed layer digests). Note:
+                # the image config JSON uses lowercase
+                # keys (rootfs.diff_ids), not the
+                # capitalized Docker inspect format
+                # (RootFS.Layers).
+                config_json = json.loads(config_data)
+                raw_diff_ids = config_json.get(
+                    'rootfs', {}).get('diff_ids', [])
+                diff_ids = []
+                for d in raw_diff_ids:
+                    if d.startswith('sha256:'):
+                        diff_ids.append(d[7:])
+                    else:
+                        diff_ids.append(d)
+
+                layers = manifest.get('layers', [])
+                if len(diff_ids) != len(layers):
+                    raise Exception(
+                        'DiffID count (%d) does not'
+                        ' match layer count (%d)'
+                        % (len(diff_ids), len(layers)))
+
+                # Yield layers
+                layers_fetched = 0
+                layers_skipped = 0
+
+                for layer_idx, (layer_meta, diff_id) \
+                        in enumerate(
+                            zip(layers, diff_ids)):
+                    idx = (layer_idx
+                           if not ordered else None)
+
+                    if not fetch_callback(diff_id):
+                        LOG.info(
+                            '[%d/%d] Skipping layer'
+                            ' %s... (fetch callback)'
+                            % (layer_idx + 1,
+                               len(layers),
+                               diff_id[:12]))
+                        yield constants.ImageElement(
+                            constants.IMAGE_LAYER,
+                            diff_id, None,
+                            layer_index=idx)
+                        layers_skipped += 1
+                        continue
+
+                    # Get compressed blob
+                    compressed_digest = layer_meta[
+                        'digest']
+                    compressed_hex = \
+                        compressed_digest.split(
+                            ':')[1]
+
+                    # Update digest mapping for
+                    # future cache runs
+                    digest_mapping[
+                        compressed_hex] = diff_id
+
+                    # If Docker skipped upload (blob
+                    # not in state.blobs), the layer
+                    # was cached and HEAD returned 200
+                    if compressed_hex \
+                            not in state.blobs:
+                        if compressed_hex \
+                                in state.skip_digests:
+                            LOG.info(
+                                '[%d/%d] Skipping'
+                                ' layer %s...'
+                                ' (cached, HEAD'
+                                ' skip)'
+                                % (layer_idx + 1,
+                                   len(layers),
+                                   diff_id[:12]))
+                            yield constants\
+                                .ImageElement(
+                                    constants
+                                    .IMAGE_LAYER,
+                                    diff_id, None,
+                                    layer_index=idx)
+                            layers_skipped += 1
+                            continue
+                        raise Exception(
+                            'Layer blob %s not'
+                            ' received'
+                            % compressed_digest)
+
+                    blob_path = state.blobs[
+                        compressed_hex]
+
+                    # Detect and decompress
+                    media_type = layer_meta.get(
+                        'mediaType')
+                    comp_type = compression\
+                        .detect_compression_from_media_type(
+                            media_type)
+                    if comp_type == constants\
+                            .COMPRESSION_UNKNOWN:
+                        with open(
+                                blob_path, 'rb') as f:
+                            comp_type = compression\
+                                .detect_compression(f)
+
+                    with open(blob_path, 'rb') as f:
+                        blob_data = f.read()
+
+                    if comp_type in (
+                            constants.COMPRESSION_GZIP,
+                            constants
+                            .COMPRESSION_ZSTD):
+                        decompressed = compression\
+                            .decompress_data(
+                                blob_data, comp_type)
+                    else:
+                        decompressed = blob_data
+
+                    LOG.info(
+                        '[%d/%d] Layer %s...'
+                        ' (%d bytes compressed,'
+                        ' %d decompressed)'
+                        % (layer_idx + 1,
+                           len(layers),
+                           diff_id[:12],
+                           len(blob_data),
+                           len(decompressed)))
+
+                    yield constants.ImageElement(
+                        constants.IMAGE_LAYER,
+                        diff_id,
+                        io.BytesIO(decompressed),
+                        layer_index=idx)
+                    layers_fetched += 1
+
+                # Save updated digest mapping
+                self._save_digest_mapping(
+                    digest_mapping)
+
+                LOG.info(
+                    'Done: %d layer(s) fetched,'
+                    ' %d skipped'
+                    % (layers_fetched,
+                       layers_skipped))
+
+            finally:
+                # Untag the localhost image
+                try:
+                    self._untag_image(
+                        push_repo, self._tag)
+                except Exception:
+                    LOG.warning(
+                        'Failed to untag %s:%s'
+                        % (push_repo, self._tag))
+
+        finally:
+            # Stop server and clean up temp files
+            self._stop_server(server)
+            for path in state.blobs.values():
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            # Clean up any abandoned uploads
+            for upload in state.uploads.values():
+                try:
+                    os.unlink(upload['path'])
+                except OSError:
+                    pass

--- a/occystrap/inputs/dockerpush.py
+++ b/occystrap/inputs/dockerpush.py
@@ -30,13 +30,14 @@ import os
 import tempfile
 import threading
 import uuid
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import (
+    urlparse, parse_qs, quote, urlencode)
 
 import requests_unixsocket
 
 from occystrap import compression
 from occystrap import constants
-from occystrap.inputs.base import ImageInput
+from occystrap.inputs.base import ImageInput, always_fetch
 
 
 LOG = logging.getLogger(__name__)
@@ -50,10 +51,6 @@ COPY_BUFSIZE = 1024 * 1024  # 1MB chunks
 # after the push API call completes. Large images on
 # slow systems may need more time.
 MANIFEST_TIMEOUT = 300
-
-
-def always_fetch(digest):
-    return True
 
 
 class _RegistryState:
@@ -97,6 +94,10 @@ class EmbeddedRegistryHandler(
     All received blobs are stored as temp files. The manifest
     is stored in memory.
     """
+
+    # Close idle connections after 30 seconds to
+    # prevent stale handler threads from lingering.
+    timeout = 30
 
     @property
     def state(self):
@@ -498,8 +499,9 @@ class Image(ImageInput):
         pointing to the same image.
         """
         ref = self._get_image_reference()
-        path = '/images/%s/tag?repo=%s&tag=%s' % (
-            ref, repo, tag)
+        params = urlencode({'repo': repo, 'tag': tag})
+        path = '/images/%s/tag?%s' % (
+            quote(ref, safe=''), params)
         r = self._request('POST', path)
         if r.status_code == 404:
             raise Exception(
@@ -517,7 +519,8 @@ class Image(ImageInput):
         Consumes the stream and checks for errors.
         """
         push_ref = '%s:%s' % (repo, tag)
-        path = '/images/%s/push' % push_ref
+        path = '/images/%s/push' % quote(
+            push_ref, safe='')
         auth_header = base64.b64encode(
             b'{}').decode('ascii')
         r = self._request(
@@ -561,7 +564,8 @@ class Image(ImageInput):
         only the tag without deleting underlying layers.
         """
         ref = '%s:%s' % (repo, tag)
-        path = '/images/%s?noprune=true' % ref
+        path = '/images/%s?noprune=true' % quote(
+            ref, safe='')
         r = self._request('DELETE', path)
         if r.status_code in (200, 404):
             LOG.info('Untagged %s' % ref)
@@ -773,6 +777,23 @@ class Image(ImageInput):
                 # Parse manifest
                 manifest = json.loads(
                     state.manifest_data)
+
+                # Detect manifest list (multi-arch)
+                # which we don't support - Docker
+                # should always push a single-platform
+                # manifest, but check just in case.
+                if 'manifests' in manifest:
+                    raise Exception(
+                        'Received a manifest list'
+                        ' (multi-arch) instead of a'
+                        ' single image manifest.'
+                        ' This is unexpected for a'
+                        ' Docker push. Please ensure'
+                        ' the image is single-platform'
+                        ' or use registry:// input'
+                        ' which supports manifest'
+                        ' list resolution.')
+
                 LOG.info(
                     'Manifest received: %d layers'
                     % len(manifest.get('layers', [])))
@@ -954,7 +975,8 @@ class Image(ImageInput):
                         os.unlink(blob_path)
                     except OSError:
                         pass
-                    del state.blobs[compressed_hex]
+                    with state.lock:
+                        del state.blobs[compressed_hex]
 
                     LOG.info(
                         '[%d/%d] Layer %s...'

--- a/occystrap/inputs/registry.py
+++ b/occystrap/inputs/registry.py
@@ -23,7 +23,7 @@ import time
 from occystrap import compression
 from occystrap import constants
 from occystrap import util
-from occystrap.inputs.base import ImageInput
+from occystrap.inputs.base import ImageInput, always_fetch
 
 # Retry configuration
 MAX_RETRIES = 3
@@ -33,10 +33,6 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 DELETED_FILE_RE = re.compile(r'.*/\.wh\.(.*)$')
-
-
-def always_fetch(digest):
-    return True
 
 
 class Image(ImageInput):

--- a/occystrap/inputs/tarfile.py
+++ b/occystrap/inputs/tarfile.py
@@ -6,15 +6,11 @@ import tarfile
 
 from occystrap import compression
 from occystrap import constants
-from occystrap.inputs.base import ImageInput
+from occystrap.inputs.base import ImageInput, always_fetch
 
 
 LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
-
-
-def always_fetch(digest):
-    return True
 
 
 class Image(ImageInput):

--- a/occystrap/layer_cache.py
+++ b/occystrap/layer_cache.py
@@ -141,6 +141,11 @@ class LayerCache:
         except OSError as e:
             LOG.warning('Could not save layer cache: %s', e)
 
+    @property
+    def path(self):
+        """Return the cache file path."""
+        return self._path
+
     def __len__(self):
         """Return the number of cached entries."""
         return len(self._data['layers'])

--- a/occystrap/main.py
+++ b/occystrap/main.py
@@ -101,6 +101,7 @@ def process_cmd(ctx, source, destination, filters):
     Input URI schemes:
       registry://HOST/IMAGE:TAG    - Docker/OCI registry
       docker://IMAGE:TAG           - Local Docker daemon
+      dockerpush://IMAGE:TAG       - Local Docker via push (fast)
       tar://PATH                   - Docker-save tarball
 
     \b
@@ -163,6 +164,7 @@ def search_cmd(ctx, source, pattern, regex, script_friendly):
     SOURCE is a URI specifying where to read the image from:
       registry://HOST/IMAGE:TAG    - Docker/OCI registry
       docker://IMAGE:TAG           - Local Docker daemon
+      dockerpush://IMAGE:TAG       - Local Docker via push (fast)
       tar://PATH                   - Docker-save tarball
 
     PATTERN is a glob pattern (or regex with --regex).

--- a/occystrap/pipeline.py
+++ b/occystrap/pipeline.py
@@ -48,11 +48,17 @@ class PipelineBuilder:
         """Get a value from the context object."""
         return self._ctx_obj.get(key, default)
 
-    def build_input(self, uri_spec):
+    def build_input(self, uri_spec, layer_cache=None,
+                    filters_hash='none'):
         """Create an ImageInput from a URI spec.
 
         Args:
             uri_spec: A URISpec from uri.parse_uri()
+            layer_cache: Optional LayerCache instance.
+                Only used by dockerpush:// for the HEAD
+                optimization that skips cached layers.
+            filters_hash: Hash of the pipeline config,
+                used with layer_cache (default: 'none').
 
         Returns:
             An ImageInput instance.
@@ -104,7 +110,9 @@ class PipelineBuilder:
             temp_dir = self._get_ctx('TEMP_DIR')
             return input_dockerpush.Image(
                 image, tag, socket_path=socket,
-                temp_dir=temp_dir)
+                temp_dir=temp_dir,
+                layer_cache=layer_cache,
+                filters_hash=filters_hash)
 
         elif uri_spec.scheme == 'tar':
             path = uri_spec.path
@@ -346,20 +354,12 @@ class PipelineBuilder:
                 filter_strs, compression_type)
             layer_cache = LayerCache(cache_path)
 
-        # Build input (pass cache to dockerpush for
-        # HEAD optimization)
-        if source_spec.scheme == 'dockerpush' \
-                and layer_cache is not None:
-            image, tag, socket = \
-                uri.parse_dockerpush_uri(source_spec)
-            temp_dir = self._get_ctx('TEMP_DIR')
-            input_source = input_dockerpush.Image(
-                image, tag, socket_path=socket,
-                temp_dir=temp_dir,
-                layer_cache=layer_cache,
-                filters_hash=filters_hash)
-        else:
-            input_source = self.build_input(source_spec)
+        # Build input (layer_cache and filters_hash are
+        # passed through to dockerpush for the HEAD
+        # optimization; other inputs ignore them)
+        input_source = self.build_input(
+            source_spec, layer_cache=layer_cache,
+            filters_hash=filters_hash)
 
         # Build output
         output = self.build_output(

--- a/occystrap/pipeline.py
+++ b/occystrap/pipeline.py
@@ -9,6 +9,7 @@ import json
 import os
 
 from occystrap.inputs import docker as input_docker
+from occystrap.inputs import dockerpush as input_dockerpush
 from occystrap.inputs import registry as input_registry
 from occystrap.inputs import tarfile as input_tarfile
 from occystrap.layer_cache import LayerCache
@@ -96,6 +97,14 @@ class PipelineBuilder:
             temp_dir = self._get_ctx('TEMP_DIR')
             return input_docker.Image(
                 image, tag, socket_path=socket, temp_dir=temp_dir)
+
+        elif uri_spec.scheme == 'dockerpush':
+            image, tag, socket = \
+                uri.parse_dockerpush_uri(uri_spec)
+            temp_dir = self._get_ctx('TEMP_DIR')
+            return input_dockerpush.Image(
+                image, tag, socket_path=socket,
+                temp_dir=temp_dir)
 
         elif uri_spec.scheme == 'tar':
             path = uri_spec.path
@@ -322,10 +331,10 @@ class PipelineBuilder:
         dest_spec = uri.parse_uri(dest_uri_str)
         filter_specs = [uri.parse_filter(f) for f in filter_strs]
 
-        # Build input
-        input_source = self.build_input(source_spec)
-
-        # Set up layer cache for registry outputs
+        # Set up layer cache for registry outputs.
+        # Compute early so dockerpush input can use it
+        # for the HEAD optimization (skipping cached
+        # layers before Docker even uploads them).
         layer_cache = None
         filters_hash = 'none'
         cache_path = self._get_ctx('LAYER_CACHE')
@@ -336,6 +345,21 @@ class PipelineBuilder:
             filters_hash = self._compute_filters_hash(
                 filter_strs, compression_type)
             layer_cache = LayerCache(cache_path)
+
+        # Build input (pass cache to dockerpush for
+        # HEAD optimization)
+        if source_spec.scheme == 'dockerpush' \
+                and layer_cache is not None:
+            image, tag, socket = \
+                uri.parse_dockerpush_uri(source_spec)
+            temp_dir = self._get_ctx('TEMP_DIR')
+            input_source = input_dockerpush.Image(
+                image, tag, socket_path=socket,
+                temp_dir=temp_dir,
+                layer_cache=layer_cache,
+                filters_hash=filters_hash)
+        else:
+            input_source = self.build_input(source_spec)
 
         # Build output
         output = self.build_output(

--- a/occystrap/tests/test_dockerpush.py
+++ b/occystrap/tests/test_dockerpush.py
@@ -1,0 +1,682 @@
+"""Tests for the dockerpush input module."""
+
+import gzip
+import hashlib
+import http.server
+import json
+import os
+import threading
+import unittest
+from unittest import mock
+
+import requests
+
+from occystrap import constants
+from occystrap.inputs.dockerpush import (
+    EmbeddedRegistryHandler,
+    Image,
+    _RegistryState,
+)
+
+
+def _start_test_server(state=None):
+    """Start a test registry server and return (server, port)."""
+    if state is None:
+        state = _RegistryState()
+    server = http.server.ThreadingHTTPServer(
+        ('127.0.0.1', 0), EmbeddedRegistryHandler)
+    server.registry_state = state
+    thread = threading.Thread(
+        target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, server.server_address[1]
+
+
+class TestEmbeddedRegistryV2Check(unittest.TestCase):
+    """Tests for GET /v2/ version check."""
+
+    def setUp(self):
+        self.server, self.port = _start_test_server()
+        self.base = 'http://127.0.0.1:%d' % self.port
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_v2_returns_200(self):
+        r = requests.get('%s/v2/' % self.base)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {})
+
+    def test_v2_has_api_version_header(self):
+        r = requests.get('%s/v2/' % self.base)
+        self.assertEqual(
+            r.headers.get('Docker-Distribution-API-Version'),
+            'registry/2.0')
+
+    def test_unknown_get_returns_404(self):
+        r = requests.get('%s/v2/unknown' % self.base)
+        self.assertEqual(r.status_code, 404)
+
+
+class TestEmbeddedRegistryHEAD(unittest.TestCase):
+    """Tests for HEAD /v2/{name}/blobs/{digest}."""
+
+    def setUp(self):
+        self.server, self.port = _start_test_server()
+        self.base = 'http://127.0.0.1:%d' % self.port
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_head_returns_404_not_cached(self):
+        """HEAD returns 404 for unknown digests."""
+        r = requests.head(
+            '%s/v2/test/blobs/sha256:abc123' % self.base)
+        self.assertEqual(r.status_code, 404)
+
+    def test_head_returns_200_for_skip_digest(self):
+        """HEAD returns 200 for digests in skip_digests."""
+        state = self.server.registry_state
+        state.skip_digests.add('abc123')
+        r = requests.head(
+            '%s/v2/test/blobs/sha256:abc123' % self.base)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.headers.get('Docker-Content-Digest'),
+            'sha256:abc123')
+
+    def test_head_returns_404_for_non_skip_digest(self):
+        """HEAD returns 404 for digests NOT in skip set."""
+        state = self.server.registry_state
+        state.skip_digests.add('abc123')
+        r = requests.head(
+            '%s/v2/test/blobs/sha256:def456' % self.base)
+        self.assertEqual(r.status_code, 404)
+
+
+class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
+    """Tests for the blob upload flow (POST/PATCH/PUT)."""
+
+    def setUp(self):
+        self.state = _RegistryState()
+        self.server, self.port = _start_test_server(
+            self.state)
+        self.base = 'http://127.0.0.1:%d' % self.port
+
+    def tearDown(self):
+        self.server.shutdown()
+        # Clean up any temp files
+        for path in self.state.blobs.values():
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        for upload in self.state.uploads.values():
+            try:
+                os.unlink(upload['path'])
+            except OSError:
+                pass
+
+    def test_post_creates_upload(self):
+        r = requests.post(
+            '%s/v2/test/blobs/uploads/' % self.base)
+        self.assertEqual(r.status_code, 202)
+        self.assertIn(
+            'Docker-Upload-UUID', r.headers)
+        self.assertIn('Location', r.headers)
+
+    def test_chunked_upload_flow(self):
+        """Test POST -> PATCH -> PUT chunked upload."""
+        blob_data = b'hello world blob data'
+        blob_hash = hashlib.sha256(blob_data).hexdigest()
+
+        # POST to start upload
+        r = requests.post(
+            '%s/v2/test/blobs/uploads/' % self.base)
+        self.assertEqual(r.status_code, 202)
+        location = r.headers['Location']
+
+        # PATCH to send data
+        r = requests.patch(
+            '%s%s' % (self.base, location),
+            data=blob_data,
+            headers={
+                'Content-Type':
+                    'application/octet-stream'
+            })
+        self.assertEqual(r.status_code, 202)
+
+        # PUT to complete with digest
+        r = requests.put(
+            '%s%s?digest=sha256:%s'
+            % (self.base, location, blob_hash))
+        self.assertEqual(r.status_code, 201)
+        self.assertIn(blob_hash, self.state.blobs)
+
+    def test_monolithic_upload(self):
+        """Test POST -> PUT monolithic upload."""
+        blob_data = b'monolithic blob content'
+        blob_hash = hashlib.sha256(blob_data).hexdigest()
+
+        # POST to start upload
+        r = requests.post(
+            '%s/v2/test/blobs/uploads/' % self.base)
+        location = r.headers['Location']
+
+        # PUT with all data and digest
+        r = requests.put(
+            '%s%s?digest=sha256:%s'
+            % (self.base, location, blob_hash),
+            data=blob_data,
+            headers={
+                'Content-Type':
+                    'application/octet-stream'
+            })
+        self.assertEqual(r.status_code, 201)
+        self.assertIn(blob_hash, self.state.blobs)
+
+    def test_put_with_wrong_digest_returns_400(self):
+        """Test that digest mismatch returns 400."""
+        blob_data = b'some blob data'
+        wrong_hash = 'a' * 64
+
+        r = requests.post(
+            '%s/v2/test/blobs/uploads/' % self.base)
+        location = r.headers['Location']
+
+        r = requests.put(
+            '%s%s?digest=sha256:%s'
+            % (self.base, location, wrong_hash),
+            data=blob_data)
+        self.assertEqual(r.status_code, 400)
+        self.assertNotIn(wrong_hash, self.state.blobs)
+
+
+class TestEmbeddedRegistryManifest(unittest.TestCase):
+    """Tests for PUT /v2/{name}/manifests/{tag}."""
+
+    def setUp(self):
+        self.state = _RegistryState()
+        self.server, self.port = _start_test_server(
+            self.state)
+        self.base = 'http://127.0.0.1:%d' % self.port
+
+    def tearDown(self):
+        self.server.shutdown()
+
+    def test_manifest_put_stores_data(self):
+        manifest = json.dumps({
+            'schemaVersion': 2,
+            'config': {
+                'digest': 'sha256:abc',
+                'size': 100,
+            },
+            'layers': [],
+        }).encode()
+
+        r = requests.put(
+            '%s/v2/test/manifests/latest' % self.base,
+            data=manifest,
+            headers={
+                'Content-Type':
+                    'application/'
+                    'vnd.docker.distribution'
+                    '.manifest.v2+json'
+            })
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(
+            self.state.manifest_data, manifest)
+
+    def test_manifest_put_signals_event(self):
+        manifest = b'{"schemaVersion": 2}'
+
+        requests.put(
+            '%s/v2/test/manifests/latest' % self.base,
+            data=manifest)
+        self.assertTrue(
+            self.state.manifest_event.is_set())
+
+
+class TestImageDockerAPI(unittest.TestCase):
+    """Tests for Image class Docker API helpers."""
+
+    def _make_image(self, socket_path='/var/run/docker.sock'):
+        return Image(
+            'busybox', tag='latest',
+            socket_path=socket_path)
+
+    def test_image_properties(self):
+        img = self._make_image()
+        self.assertEqual(img.image, 'busybox')
+        self.assertEqual(img.tag, 'latest')
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
+    def test_tag_image(self, mock_session_cls):
+        mock_session = mock.MagicMock()
+        mock_session.request.return_value = mock.MagicMock(
+            status_code=201)
+        mock_session_cls.return_value = mock_session
+
+        img = self._make_image()
+        img._tag_image('localhost:5000/busybox', 'latest')
+
+        mock_session.request.assert_called_once()
+        call_args = mock_session.request.call_args
+        self.assertEqual(call_args[0][0], 'POST')
+        self.assertIn('/images/', call_args[0][1])
+        self.assertIn('tag', call_args[0][1])
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
+    def test_tag_image_404_raises(self, mock_session_cls):
+        mock_session = mock.MagicMock()
+        mock_session.request.return_value = mock.MagicMock(
+            status_code=404)
+        mock_session_cls.return_value = mock_session
+
+        img = self._make_image()
+        with self.assertRaises(Exception):
+            img._tag_image(
+                'localhost:5000/busybox', 'latest')
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
+    def test_untag_image(self, mock_session_cls):
+        mock_session = mock.MagicMock()
+        mock_session.request.return_value = mock.MagicMock(
+            status_code=200)
+        mock_session_cls.return_value = mock_session
+
+        img = self._make_image()
+        img._untag_image('localhost:5000/busybox', 'latest')
+
+        mock_session.request.assert_called_once()
+        call_args = mock_session.request.call_args
+        self.assertEqual(call_args[0][0], 'DELETE')
+        self.assertIn('noprune=true', call_args[0][1])
+
+
+class TestImageFetch(unittest.TestCase):
+    """Tests for the Image.fetch() method.
+
+    These tests use a real embedded registry but mock the
+    Docker daemon API calls.
+    """
+
+    def _make_gzip_layer(self, content):
+        """Create a gzip-compressed layer with known digest."""
+        compressed = gzip.compress(content)
+        compressed_hash = hashlib.sha256(
+            compressed).hexdigest()
+        uncompressed_hash = hashlib.sha256(
+            content).hexdigest()
+        return compressed, compressed_hash, \
+            uncompressed_hash
+
+    def _make_config(self, diff_ids):
+        """Create a config blob with the given DiffIDs."""
+        config = {
+            'rootfs': {
+                'type': 'layers',
+                'diff_ids': [
+                    'sha256:%s' % d for d in diff_ids
+                ],
+            },
+        }
+        config_bytes = json.dumps(config).encode()
+        config_hash = hashlib.sha256(
+            config_bytes).hexdigest()
+        return config_bytes, config_hash
+
+    def _make_manifest(self, config_hash, config_size,
+                       layers):
+        """Create a manifest with config and layers."""
+        docker_config_type = \
+            constants.MEDIA_TYPE_DOCKER_CONFIG
+        docker_layer_type = \
+            constants.MEDIA_TYPE_DOCKER_LAYER_GZIP
+        manifest = {
+            'schemaVersion': 2,
+            'config': {
+                'mediaType': docker_config_type,
+                'digest': 'sha256:%s' % config_hash,
+                'size': config_size,
+            },
+            'layers': [
+                {
+                    'mediaType': docker_layer_type,
+                    'digest':
+                        'sha256:%s' % comp_hash,
+                    'size': comp_size,
+                }
+                for comp_hash, comp_size in layers
+            ],
+        }
+        return json.dumps(manifest).encode()
+
+    def _upload_blob_to_server(self, base, data,
+                               digest_hex):
+        """Upload a blob to the test server."""
+        r = requests.post(
+            '%s/v2/test/blobs/uploads/' % base)
+        location = r.headers['Location']
+        requests.put(
+            '%s%s?digest=sha256:%s'
+            % (base, location, digest_hex),
+            data=data)
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
+    def test_fetch_single_layer(self, mock_session_cls):
+        """Test fetching an image with one layer."""
+        layer_content = b'layer tar data here'
+        compressed, comp_hash, uncomp_hash = \
+            self._make_gzip_layer(layer_content)
+        config_bytes, config_hash = self._make_config(
+            [uncomp_hash])
+        manifest = self._make_manifest(
+            config_hash, len(config_bytes),
+            [(comp_hash, len(compressed))])
+
+        # Mock Docker API responses
+        mock_session = mock.MagicMock()
+
+        def mock_request(method, url, stream=False,
+                         headers=None, data=None):
+            resp = mock.MagicMock()
+            if method == 'POST' and '/tag' in url:
+                resp.status_code = 201
+                return resp
+            elif method == 'POST' and '/push' in url:
+                resp.status_code = 200
+                resp.iter_lines.return_value = [
+                    json.dumps(
+                        {'status': 'Pushing'}).encode(),
+                ]
+                return resp
+            elif method == 'DELETE':
+                resp.status_code = 200
+                return resp
+            resp.status_code = 404
+            return resp
+
+        mock_session.request.side_effect = mock_request
+        mock_session_cls.return_value = mock_session
+
+        img = Image('test', tag='latest')
+        # We need to start the server ourselves
+        # and push the blobs manually since we're mocking
+        # Docker's push
+        state = _RegistryState()
+        server = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', 0), EmbeddedRegistryHandler)
+        server.registry_state = state
+        thread = threading.Thread(
+            target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        base = 'http://127.0.0.1:%d' % port
+
+        try:
+            # Upload blobs to the test server
+            self._upload_blob_to_server(
+                base, config_bytes, config_hash)
+            self._upload_blob_to_server(
+                base, compressed, comp_hash)
+
+            # Upload manifest
+            requests.put(
+                '%s/v2/test/manifests/latest' % base,
+                data=manifest)
+
+            # Monkey-patch to use our server
+            def fake_start(s):
+                server.registry_state = s
+                # Copy blobs from our state
+                s.blobs.update(state.blobs)
+                s.manifest_data = state.manifest_data
+                s.manifest_event.set()
+                return server
+
+            def fake_stop(s):
+                pass  # Don't stop, we do it ourselves
+
+            img._start_server = fake_start
+            img._stop_server = fake_stop
+
+            elements = list(img.fetch())
+
+            # Should have config + 1 layer = 2 elements
+            self.assertEqual(len(elements), 2)
+            self.assertEqual(
+                elements[0].element_type,
+                constants.CONFIG_FILE)
+            self.assertEqual(
+                elements[0].name,
+                '%s.json' % config_hash)
+            self.assertEqual(
+                elements[1].element_type,
+                constants.IMAGE_LAYER)
+            self.assertEqual(
+                elements[1].name, uncomp_hash)
+            # Layer data should be decompressed
+            self.assertEqual(
+                elements[1].data.read(),
+                layer_content)
+        finally:
+            server.shutdown()
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
+    def test_fetch_callback_skip(self, mock_session_cls):
+        """Test that fetch_callback=False skips layers."""
+        layer_content = b'layer data'
+        compressed, comp_hash, uncomp_hash = \
+            self._make_gzip_layer(layer_content)
+        config_bytes, config_hash = self._make_config(
+            [uncomp_hash])
+        manifest = self._make_manifest(
+            config_hash, len(config_bytes),
+            [(comp_hash, len(compressed))])
+
+        mock_session = mock.MagicMock()
+
+        def mock_request(method, url, stream=False,
+                         headers=None, data=None):
+            resp = mock.MagicMock()
+            if method == 'POST' and '/tag' in url:
+                resp.status_code = 201
+            elif method == 'POST' and '/push' in url:
+                resp.status_code = 200
+                resp.iter_lines.return_value = []
+            elif method == 'DELETE':
+                resp.status_code = 200
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_session.request.side_effect = mock_request
+        mock_session_cls.return_value = mock_session
+
+        img = Image('test', tag='latest')
+        state = _RegistryState()
+        server = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', 0), EmbeddedRegistryHandler)
+        server.registry_state = state
+        thread = threading.Thread(
+            target=server.serve_forever, daemon=True)
+        thread.start()
+        base = 'http://127.0.0.1:%d' \
+            % server.server_address[1]
+
+        try:
+            self._upload_blob_to_server(
+                base, config_bytes, config_hash)
+            self._upload_blob_to_server(
+                base, compressed, comp_hash)
+            requests.put(
+                '%s/v2/test/manifests/latest' % base,
+                data=manifest)
+
+            def fake_start(s):
+                server.registry_state = s
+                s.blobs.update(state.blobs)
+                s.manifest_data = state.manifest_data
+                s.manifest_event.set()
+                return server
+
+            img._start_server = fake_start
+            img._stop_server = lambda s: None
+
+            # Skip all layers
+            elements = list(
+                img.fetch(
+                    fetch_callback=lambda d: False))
+
+            self.assertEqual(len(elements), 2)
+            # Config should still have data
+            self.assertIsNotNone(elements[0].data)
+            # Layer should have None data
+            self.assertIsNone(elements[1].data)
+        finally:
+            server.shutdown()
+
+
+class TestDigestMapping(unittest.TestCase):
+    """Tests for digest mapping persistence."""
+
+    def setUp(self):
+        import tempfile
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir)
+
+    def test_save_and_load_digest_mapping(self):
+        """Test round-trip of digest mapping file."""
+        cache_path = os.path.join(
+            self.temp_dir, 'cache.json')
+        from occystrap.layer_cache import LayerCache
+        cache = LayerCache(cache_path)
+
+        img = Image(
+            'test', tag='latest',
+            layer_cache=cache,
+            filters_hash='none')
+
+        mappings = {
+            'abc123': 'def456',
+            'ghi789': 'jkl012',
+        }
+        img._save_digest_mapping(mappings)
+
+        loaded = img._load_digest_mapping()
+        self.assertEqual(loaded, mappings)
+
+    def test_load_missing_file_returns_empty(self):
+        """Test loading from nonexistent file."""
+        cache_path = os.path.join(
+            self.temp_dir, 'missing.json')
+        from occystrap.layer_cache import LayerCache
+        cache = LayerCache(cache_path)
+
+        img = Image(
+            'test', tag='latest',
+            layer_cache=cache,
+            filters_hash='none')
+
+        loaded = img._load_digest_mapping()
+        self.assertEqual(loaded, {})
+
+    def test_no_cache_returns_empty(self):
+        """Test that no cache means no mapping."""
+        img = Image('test', tag='latest')
+        loaded = img._load_digest_mapping()
+        self.assertEqual(loaded, {})
+
+    def test_build_skip_digests_empty_without_cache(
+            self):
+        """Test skip_digests is empty without cache."""
+        img = Image('test', tag='latest')
+        skip, mapping = img._build_skip_digests(
+            lambda d: True)
+        self.assertEqual(skip, set())
+        self.assertEqual(mapping, {})
+
+    def test_build_skip_digests_with_cache(self):
+        """Test skip_digests populated from cache."""
+        cache_path = os.path.join(
+            self.temp_dir, 'cache.json')
+        from occystrap.layer_cache import LayerCache
+        cache = LayerCache(cache_path)
+
+        # Record a cached layer
+        cache.record(
+            'diff_abc', 'none',
+            'sha256:comp_xyz', 100,
+            'application/vnd.docker.image.'
+            'rootfs.diff.tar.gzip')
+
+        img = Image(
+            'test', tag='latest',
+            layer_cache=cache,
+            filters_hash='none')
+
+        # Save a mapping:
+        # docker compressed hex -> diffid hex
+        img._save_digest_mapping(
+            {'docker_comp_hex': 'diff_abc'})
+
+        # Build skip digests. fetch_callback
+        # returns False (meaning output says "skip").
+        skip, mapping = img._build_skip_digests(
+            lambda d: False)
+        self.assertIn('docker_comp_hex', skip)
+
+
+class TestURIParsing(unittest.TestCase):
+    """Tests for dockerpush URI parsing."""
+
+    def test_parse_dockerpush_uri(self):
+        from occystrap import uri
+        spec = uri.parse_uri('dockerpush://busybox:latest')
+        image, tag, socket = \
+            uri.parse_dockerpush_uri(spec)
+        self.assertEqual(image, 'busybox')
+        self.assertEqual(tag, 'latest')
+        self.assertEqual(
+            socket, '/var/run/docker.sock')
+
+    def test_parse_dockerpush_uri_with_socket(self):
+        from occystrap import uri
+        spec = uri.parse_uri(
+            'dockerpush://busybox:v1'
+            '?socket=/run/podman/podman.sock')
+        image, tag, socket = \
+            uri.parse_dockerpush_uri(spec)
+        self.assertEqual(image, 'busybox')
+        self.assertEqual(tag, 'v1')
+        self.assertEqual(
+            socket, '/run/podman/podman.sock')
+
+    def test_dockerpush_in_input_schemes(self):
+        from occystrap import uri
+        self.assertIn(
+            'dockerpush', uri.INPUT_SCHEMES)
+
+    def test_wrong_scheme_raises(self):
+        from occystrap import uri
+        spec = uri.parse_uri('docker://busybox:latest')
+        with self.assertRaises(uri.URIParseError):
+            uri.parse_dockerpush_uri(spec)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/occystrap/tests/test_dockerpush.py
+++ b/occystrap/tests/test_dockerpush.py
@@ -465,9 +465,20 @@ class TestImageFetch(unittest.TestCase):
             img._start_server = fake_start
             img._stop_server = fake_stop
 
-            elements = list(img.fetch())
+            # Consume elements one at a time so
+            # file handles stay open (the generator
+            # closes them on resume, matching
+            # registry.py's pattern)
+            elements = []
+            layer_data = None
+            for elem in img.fetch():
+                if elem.element_type == \
+                        constants.IMAGE_LAYER \
+                        and elem.data is not None:
+                    layer_data = elem.data.read()
+                elements.append(elem)
 
-            # Should have config + 1 layer = 2 elements
+            # Should have config + 1 layer
             self.assertEqual(len(elements), 2)
             self.assertEqual(
                 elements[0].element_type,
@@ -482,8 +493,7 @@ class TestImageFetch(unittest.TestCase):
                 elements[1].name, uncomp_hash)
             # Layer data should be decompressed
             self.assertEqual(
-                elements[1].data.read(),
-                layer_content)
+                layer_data, layer_content)
         finally:
             server.shutdown()
 

--- a/occystrap/tests/test_dockerpush.py
+++ b/occystrap/tests/test_dockerpush.py
@@ -32,29 +32,41 @@ def _start_test_server(state=None):
     return server, server.server_address[1]
 
 
+def _no_proxy_session():
+    """Create a requests session that bypasses proxy settings.
+
+    CI runners may have HTTP_PROXY set, which would route
+    localhost requests through the proxy and break tests.
+    """
+    s = requests.Session()
+    s.trust_env = False
+    return s
+
+
 class TestEmbeddedRegistryV2Check(unittest.TestCase):
     """Tests for GET /v2/ version check."""
 
     def setUp(self):
         self.server, self.port = _start_test_server()
         self.base = 'http://127.0.0.1:%d' % self.port
+        self.sess = _no_proxy_session()
 
     def tearDown(self):
         self.server.shutdown()
 
     def test_v2_returns_200(self):
-        r = requests.get('%s/v2/' % self.base)
+        r = self.sess.get('%s/v2/' % self.base)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json(), {})
 
     def test_v2_has_api_version_header(self):
-        r = requests.get('%s/v2/' % self.base)
+        r = self.sess.get('%s/v2/' % self.base)
         self.assertEqual(
             r.headers.get('Docker-Distribution-API-Version'),
             'registry/2.0')
 
     def test_unknown_get_returns_404(self):
-        r = requests.get('%s/v2/unknown' % self.base)
+        r = self.sess.get('%s/v2/unknown' % self.base)
         self.assertEqual(r.status_code, 404)
 
 
@@ -64,13 +76,14 @@ class TestEmbeddedRegistryHEAD(unittest.TestCase):
     def setUp(self):
         self.server, self.port = _start_test_server()
         self.base = 'http://127.0.0.1:%d' % self.port
+        self.sess = _no_proxy_session()
 
     def tearDown(self):
         self.server.shutdown()
 
     def test_head_returns_404_not_cached(self):
         """HEAD returns 404 for unknown digests."""
-        r = requests.head(
+        r = self.sess.head(
             '%s/v2/test/blobs/sha256:abc123' % self.base)
         self.assertEqual(r.status_code, 404)
 
@@ -78,7 +91,7 @@ class TestEmbeddedRegistryHEAD(unittest.TestCase):
         """HEAD returns 200 for digests in skip_digests."""
         state = self.server.registry_state
         state.skip_digests.add('abc123')
-        r = requests.head(
+        r = self.sess.head(
             '%s/v2/test/blobs/sha256:abc123' % self.base)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
@@ -89,7 +102,7 @@ class TestEmbeddedRegistryHEAD(unittest.TestCase):
         """HEAD returns 404 for digests NOT in skip set."""
         state = self.server.registry_state
         state.skip_digests.add('abc123')
-        r = requests.head(
+        r = self.sess.head(
             '%s/v2/test/blobs/sha256:def456' % self.base)
         self.assertEqual(r.status_code, 404)
 
@@ -102,6 +115,7 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
         self.server, self.port = _start_test_server(
             self.state)
         self.base = 'http://127.0.0.1:%d' % self.port
+        self.sess = _no_proxy_session()
 
     def tearDown(self):
         self.server.shutdown()
@@ -118,7 +132,7 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
                 pass
 
     def test_post_creates_upload(self):
-        r = requests.post(
+        r = self.sess.post(
             '%s/v2/test/blobs/uploads/' % self.base)
         self.assertEqual(r.status_code, 202)
         self.assertIn(
@@ -131,13 +145,13 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
         blob_hash = hashlib.sha256(blob_data).hexdigest()
 
         # POST to start upload
-        r = requests.post(
+        r = self.sess.post(
             '%s/v2/test/blobs/uploads/' % self.base)
         self.assertEqual(r.status_code, 202)
         location = r.headers['Location']
 
         # PATCH to send data
-        r = requests.patch(
+        r = self.sess.patch(
             '%s%s' % (self.base, location),
             data=blob_data,
             headers={
@@ -147,7 +161,7 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
         self.assertEqual(r.status_code, 202)
 
         # PUT to complete with digest
-        r = requests.put(
+        r = self.sess.put(
             '%s%s?digest=sha256:%s'
             % (self.base, location, blob_hash))
         self.assertEqual(r.status_code, 201)
@@ -159,12 +173,12 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
         blob_hash = hashlib.sha256(blob_data).hexdigest()
 
         # POST to start upload
-        r = requests.post(
+        r = self.sess.post(
             '%s/v2/test/blobs/uploads/' % self.base)
         location = r.headers['Location']
 
         # PUT with all data and digest
-        r = requests.put(
+        r = self.sess.put(
             '%s%s?digest=sha256:%s'
             % (self.base, location, blob_hash),
             data=blob_data,
@@ -180,11 +194,11 @@ class TestEmbeddedRegistryBlobUpload(unittest.TestCase):
         blob_data = b'some blob data'
         wrong_hash = 'a' * 64
 
-        r = requests.post(
+        r = self.sess.post(
             '%s/v2/test/blobs/uploads/' % self.base)
         location = r.headers['Location']
 
-        r = requests.put(
+        r = self.sess.put(
             '%s%s?digest=sha256:%s'
             % (self.base, location, wrong_hash),
             data=blob_data)
@@ -200,6 +214,7 @@ class TestEmbeddedRegistryManifest(unittest.TestCase):
         self.server, self.port = _start_test_server(
             self.state)
         self.base = 'http://127.0.0.1:%d' % self.port
+        self.sess = _no_proxy_session()
 
     def tearDown(self):
         self.server.shutdown()
@@ -214,7 +229,7 @@ class TestEmbeddedRegistryManifest(unittest.TestCase):
             'layers': [],
         }).encode()
 
-        r = requests.put(
+        r = self.sess.put(
             '%s/v2/test/manifests/latest' % self.base,
             data=manifest,
             headers={
@@ -230,7 +245,7 @@ class TestEmbeddedRegistryManifest(unittest.TestCase):
     def test_manifest_put_signals_event(self):
         manifest = b'{"schemaVersion": 2}'
 
-        requests.put(
+        self.sess.put(
             '%s/v2/test/manifests/latest' % self.base,
             data=manifest)
         self.assertTrue(
@@ -358,13 +373,13 @@ class TestImageFetch(unittest.TestCase):
         }
         return json.dumps(manifest).encode()
 
-    def _upload_blob_to_server(self, base, data,
+    def _upload_blob_to_server(self, sess, base, data,
                                digest_hex):
         """Upload a blob to the test server."""
-        r = requests.post(
+        r = sess.post(
             '%s/v2/test/blobs/uploads/' % base)
         location = r.headers['Location']
-        requests.put(
+        sess.put(
             '%s%s?digest=sha256:%s'
             % (base, location, digest_hex),
             data=data)
@@ -421,16 +436,17 @@ class TestImageFetch(unittest.TestCase):
         thread.start()
         port = server.server_address[1]
         base = 'http://127.0.0.1:%d' % port
+        sess = _no_proxy_session()
 
         try:
             # Upload blobs to the test server
             self._upload_blob_to_server(
-                base, config_bytes, config_hash)
+                sess, base, config_bytes, config_hash)
             self._upload_blob_to_server(
-                base, compressed, comp_hash)
+                sess, base, compressed, comp_hash)
 
             # Upload manifest
-            requests.put(
+            sess.put(
                 '%s/v2/test/manifests/latest' % base,
                 data=manifest)
 
@@ -514,13 +530,14 @@ class TestImageFetch(unittest.TestCase):
         thread.start()
         base = 'http://127.0.0.1:%d' \
             % server.server_address[1]
+        sess = _no_proxy_session()
 
         try:
             self._upload_blob_to_server(
-                base, config_bytes, config_hash)
+                sess, base, config_bytes, config_hash)
             self._upload_blob_to_server(
-                base, compressed, comp_hash)
-            requests.put(
+                sess, base, compressed, comp_hash)
+            sess.put(
                 '%s/v2/test/manifests/latest' % base,
                 data=manifest)
 

--- a/occystrap/tests/test_dockerpush.py
+++ b/occystrap/tests/test_dockerpush.py
@@ -500,6 +500,135 @@ class TestImageFetch(unittest.TestCase):
     @mock.patch(
         'occystrap.inputs.dockerpush'
         '.requests_unixsocket.Session')
+    def test_fetch_multi_layer(self, mock_session_cls):
+        """Test fetching an image with three layers."""
+        layer_contents = [
+            b'base layer data',
+            b'middle layer data here',
+            b'top layer with more stuff',
+        ]
+        layers_info = []
+        uncomp_hashes = []
+        for content in layer_contents:
+            compressed, comp_hash, uncomp_hash = \
+                self._make_gzip_layer(content)
+            layers_info.append(
+                (compressed, comp_hash,
+                 len(compressed)))
+            uncomp_hashes.append(uncomp_hash)
+
+        config_bytes, config_hash = self._make_config(
+            uncomp_hashes)
+        manifest = self._make_manifest(
+            config_hash, len(config_bytes),
+            [(info[1], info[2])
+             for info in layers_info])
+
+        mock_session = mock.MagicMock()
+
+        def mock_request(method, url, stream=False,
+                         headers=None, data=None):
+            resp = mock.MagicMock()
+            if method == 'POST' and '/tag' in url:
+                resp.status_code = 201
+            elif method == 'POST' and '/push' in url:
+                resp.status_code = 200
+                resp.iter_lines.return_value = [
+                    json.dumps(
+                        {'status': 'Pushing'}
+                    ).encode(),
+                ]
+            elif method == 'DELETE':
+                resp.status_code = 200
+            else:
+                resp.status_code = 404
+            return resp
+
+        mock_session.request.side_effect = \
+            mock_request
+        mock_session_cls.return_value = mock_session
+
+        img = Image('test', tag='latest')
+        state = _RegistryState()
+        server = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', 0),
+            EmbeddedRegistryHandler)
+        server.registry_state = state
+        thread = threading.Thread(
+            target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        base = 'http://127.0.0.1:%d' % port
+        sess = _no_proxy_session()
+
+        try:
+            # Upload config blob
+            self._upload_blob_to_server(
+                sess, base,
+                config_bytes, config_hash)
+
+            # Upload all layer blobs
+            for compressed, comp_hash, _ \
+                    in layers_info:
+                self._upload_blob_to_server(
+                    sess, base,
+                    compressed, comp_hash)
+
+            # Upload manifest
+            sess.put(
+                '%s/v2/test/manifests/latest'
+                % base,
+                data=manifest)
+
+            def fake_start(s):
+                server.registry_state = s
+                s.blobs.update(state.blobs)
+                s.manifest_data = \
+                    state.manifest_data
+                s.manifest_event.set()
+                return server
+
+            img._start_server = fake_start
+            img._stop_server = lambda s: None
+
+            # Consume elements one at a time
+            elements = []
+            layer_data_list = []
+            for elem in img.fetch():
+                if elem.element_type == \
+                        constants.IMAGE_LAYER \
+                        and elem.data is not None:
+                    layer_data_list.append(
+                        elem.data.read())
+                elements.append(elem)
+
+            # Should have config + 3 layers
+            self.assertEqual(len(elements), 4)
+            self.assertEqual(
+                elements[0].element_type,
+                constants.CONFIG_FILE)
+
+            # Verify each layer
+            for i in range(3):
+                self.assertEqual(
+                    elements[i + 1].element_type,
+                    constants.IMAGE_LAYER)
+                self.assertEqual(
+                    elements[i + 1].name,
+                    uncomp_hashes[i])
+
+            # Verify decompressed layer data
+            self.assertEqual(len(layer_data_list), 3)
+            for i, content in \
+                    enumerate(layer_contents):
+                self.assertEqual(
+                    layer_data_list[i], content)
+        finally:
+            server.shutdown()
+
+    @mock.patch(
+        'occystrap.inputs.dockerpush'
+        '.requests_unixsocket.Session')
     def test_fetch_callback_skip(self, mock_session_cls):
         """Test that fetch_callback=False skips layers."""
         layer_content = b'layer data'

--- a/occystrap/tests/test_registry_output.py
+++ b/occystrap/tests/test_registry_output.py
@@ -112,21 +112,25 @@ class RegistryWriterTestCase(unittest.TestCase):
     def test_upload_blob_new(self, mock_request):
         """Test uploading a new blob."""
         writer = output_registry.RegistryWriter(
-            'ghcr.io', 'myuser/myimage', 'v1.0', max_workers=1)
+            'ghcr.io', 'myuser/myimage', 'v1.0',
+            max_workers=1)
 
-        head_response = mock.MagicMock()
-        head_response.status_code = 404
+        def handler(method, url, **kwargs):
+            resp = mock.MagicMock()
+            if method == 'HEAD':
+                resp.status_code = 404
+            elif method == 'POST':
+                resp.status_code = 202
+                resp.headers = {
+                    'Location':
+                        '/v2/myuser/myimage/blobs'
+                        '/uploads/uuid123'
+                }
+            elif method == 'PUT':
+                resp.status_code = 201
+            return resp
 
-        post_response = mock.MagicMock()
-        post_response.status_code = 202
-        post_response.headers = {
-            'Location': '/v2/myuser/myimage/blobs/uploads/uuid123'
-        }
-
-        put_response = mock.MagicMock()
-        put_response.status_code = 201
-
-        mock_request.side_effect = [head_response, post_response, put_response]
+        mock_request.side_effect = handler
 
         data = io.BytesIO(b'test data')
         writer._upload_blob('sha256:abc123', data, 9)
@@ -515,22 +519,22 @@ class RegistryWriterTestCase(unittest.TestCase):
         writer = output_registry.RegistryWriter(
             'ghcr.io', 'myuser/myimage', 'v1.0')
 
-        head_response = mock.MagicMock()
-        head_response.status_code = 404
+        def handler(method, url, **kwargs):
+            resp = mock.MagicMock()
+            if method == 'HEAD':
+                resp.status_code = 404
+            elif method == 'POST':
+                resp.status_code = 202
+                resp.headers = {
+                    'Location':
+                        '/v2/myuser/myimage/blobs'
+                        '/uploads/uuid123'
+                }
+            elif method == 'PUT':
+                resp.status_code = 201
+            return resp
 
-        post_response = mock.MagicMock()
-        post_response.status_code = 202
-        post_response.headers = {
-            'Location':
-                '/v2/myuser/myimage/blobs/uploads/uuid123'
-        }
-
-        put_response = mock.MagicMock()
-        put_response.status_code = 201
-
-        mock_request.side_effect = [
-            head_response, post_response, put_response
-        ]
+        mock_request.side_effect = handler
 
         result = writer._upload_blob(
             'sha256:abc123', io.BytesIO(b'data'), 4)

--- a/occystrap/uri.py
+++ b/occystrap/uri.py
@@ -35,7 +35,9 @@ FilterSpec = namedtuple('FilterSpec', ['name', 'options'])
 
 
 # Scheme classifications
-INPUT_SCHEMES = {'registry', 'docker', 'tar', 'file'}
+INPUT_SCHEMES = {
+    'registry', 'docker', 'dockerpush', 'tar', 'file'
+}
 OUTPUT_SCHEMES = {'tar', 'dir', 'directory', 'oci', 'mounts', 'docker', 'registry'}
 
 # Scheme aliases
@@ -198,19 +200,22 @@ def parse_registry_uri(uri_spec):
     return (host, image, tag)
 
 
-def parse_docker_uri(uri_spec):
-    """Parse docker URI into (image, tag, socket) tuple.
+def _parse_docker_style_uri(uri_spec, expected_scheme):
+    """Parse a docker-style URI into (image, tag, socket) tuple.
 
-    Handles formats like:
-        docker://busybox:latest
-        docker://busybox:latest?socket=/run/podman/podman.sock
-        docker://library/busybox:v1
+    Shared logic for docker:// and dockerpush:// URIs.
+
+    Args:
+        uri_spec: Parsed URISpec.
+        expected_scheme: Expected URI scheme name.
 
     Returns:
         Tuple of (image, tag, socket_path)
     """
-    if uri_spec.scheme != 'docker':
-        raise URIParseError('Expected docker:// URI, got %s' % uri_spec.scheme)
+    if uri_spec.scheme != expected_scheme:
+        raise URIParseError(
+            'Expected %s:// URI, got %s'
+            % (expected_scheme, uri_spec.scheme))
 
     # The image:tag is in the host+path
     image_tag = uri_spec.host
@@ -226,6 +231,36 @@ def parse_docker_uri(uri_spec):
         image = image_tag
         tag = 'latest'
 
-    socket = uri_spec.options.get('socket', '/var/run/docker.sock')
+    socket = uri_spec.options.get(
+        'socket', '/var/run/docker.sock')
 
     return (image, tag, socket)
+
+
+def parse_docker_uri(uri_spec):
+    """Parse docker URI into (image, tag, socket) tuple.
+
+    Handles formats like:
+        docker://busybox:latest
+        docker://busybox:latest?socket=/run/podman/podman.sock
+        docker://library/busybox:v1
+
+    Returns:
+        Tuple of (image, tag, socket_path)
+    """
+    return _parse_docker_style_uri(uri_spec, 'docker')
+
+
+def parse_dockerpush_uri(uri_spec):
+    """Parse dockerpush URI into (image, tag, socket) tuple.
+
+    Handles formats like:
+        dockerpush://busybox:latest
+        dockerpush://busybox:latest?socket=/run/podman/podman.sock
+        dockerpush://library/busybox:v1
+
+    Returns:
+        Tuple of (image, tag, socket_path)
+    """
+    return _parse_docker_style_uri(
+        uri_spec, 'dockerpush')


### PR DESCRIPTION
Add a new input source that starts a minimal HTTP server on localhost implementing the Docker Registry V2 push-path API. Docker pushes layers to this server in parallel, which is significantly faster than the sequential tarball export used by docker://.

The embedded registry handles GET /v2/, HEAD/POST/PATCH/PUT for blob uploads, and PUT for manifests. Received blobs are stored as temp files, decompressed, and yielded as pipeline elements.

Includes layer cache integration: when --layer-cache is used with a registry:// output, the embedded registry returns 200 for HEAD checks on cached layers, causing Docker to skip uploading them entirely. A persistent digest mapping file tracks the correspondence between Docker's compressed digests and uncompressed DiffIDs.

Prompt: Implement a dockerpush:// input source for occystrap that acts as a temporary registry on localhost, receives Docker push data, and feeds it through the existing pipeline. Include layer cache optimization where the embedded registry skips cached layers.



Assisted-By: Claude Code