### PR TITLE
Document proxy TLS behavior vs dockerpush://.

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -189,6 +189,32 @@ The proxy also respects global options `--layer-cache`, `--temp-dir`,
   - Per-image locks prevent duplicate upstream fetches for concurrent
     requests
 
+**Docker insecure-registry configuration:**
+
+The proxy listens on plain HTTP. Docker normally allows insecure
+(non-TLS) access to `127.0.0.0/8` and `::1` without extra
+configuration. However, when the Docker daemon is configured with
+`containerd-snapshotter: true` in `daemon.json` (the default on some
+distributions), this localhost exception is **not honored**. In that
+case you must explicitly add the proxy listen address to
+`insecure-registries` in `daemon.json`:
+
+```json
+{
+    "insecure-registries": ["127.0.0.1:5050"]
+}
+```
+
+Restart the Docker daemon after making this change.
+
+This differs from the `dockerpush://` input, which uses HTTPS with an
+ephemeral self-signed certificate. Docker skips certificate
+verification for `127.0.0.0/8` addresses regardless of the
+containerd-snapshotter setting, so `dockerpush://` works without any
+daemon.json changes. The proxy uses plain HTTP because it is a
+standard registry server, not an embedded shim inside the occystrap
+process.
+
 **Examples:**
 
 ```bash

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -404,6 +404,17 @@ The proxy:
 - Overlaps build and push (images push as soon as they are built,
   rather than waiting for the entire build to complete)
 
+**TLS behavior difference:** The `dockerpush://` input starts an
+embedded HTTPS server with a self-signed certificate. Docker skips
+certificate verification for `127.0.0.0/8`, so it works without any
+daemon.json changes. The proxy, on the other hand, listens on plain
+HTTP. Docker normally allows insecure access to localhost, but when
+`containerd-snapshotter: true` is enabled in daemon.json this
+exception is not honored. In that case, add the proxy address
+(e.g., `127.0.0.1:5050`) to `insecure-registries` in daemon.json
+and restart Docker. See the
+[proxy command reference](command-reference.md#proxy) for details.
+
 ### Push Multiple Images with Layer Dedup
 
 ```bash


### PR DESCRIPTION
The proxy listens on plain HTTP, which normally works for localhost without configuration. However, when Docker's containerd-snapshotter feature is enabled, the localhost exception is not honored and the proxy address must be added to insecure-registries in daemon.json. This differs from dockerpush://, which uses HTTPS with a self-signed cert and works without any daemon.json changes.

Prompt: Document the distinction between dockerpush:// and Docker's native push TLS behavior in the occystrap docs.