### PR TITLE
Fix wrong diff_id for child images in proxy mode.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,15 +26,22 @@ from occystrap import constants
 from occystrap.filters.base import ImageFilter
 
 class MyFilter(ImageFilter):
-    def __init__(self, wrapped_output, option=None):
-        super().__init__(wrapped_output)
+    def __init__(self, wrapped_output, option=None,
+                 temp_dir=None, diff_id_map=None):
+        super().__init__(wrapped_output, temp_dir=temp_dir,
+                         diff_id_map=diff_id_map)
         self.option = option
 
     def process_image_element(self, element):
-        if (element.element_type == constants.IMAGE_LAYER
+        if element.element_type == constants.CONFIG_FILE:
+            self._buffer_config(element)
+        elif (element.element_type == constants.IMAGE_LAYER
                 and element.data is not None):
             # Process the layer, return modified data and new name
             new_data, new_name = self._process_layer(element.data)
+            self._record_new_diff_id(
+                new_name, element.layer_index,
+                original_hex=element.name)
             try:
                 self._wrapped.process_image_element(
                     constants.ImageElement(
@@ -45,8 +52,16 @@ class MyFilter(ImageFilter):
                 # Clean up temporary files
                 pass
         else:
+            if element.element_type == constants.IMAGE_LAYER:
+                self._skip_layer(element.layer_index)
             self._wrapped.process_image_element(element)
 ```
+
+Content-modifying filters must accept `diff_id_map` and forward it to the
+base class. This enables cross-image diff_id tracking in proxy mode (see
+`_forward_buffered_config` in `filters/base.py`). The `original_hex`
+parameter to `_record_new_diff_id` records the `original -> filtered`
+mapping. Register the `diff_id_map` kwarg in `PipelineBuilder.build_filter`.
 
 ### Adding a New Input Source
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -139,13 +139,25 @@ keeping the config's `rootfs.diff_ids` in sync:
 
 - `_buffer_config(element)` - Buffers the config element instead of forwarding
   it immediately. The config is forwarded in `finalize()` with updated diff_ids.
-- `_record_new_diff_id(sha256_hex, layer_index)` - Records the new SHA256 for
-  a modified layer.
+- `_record_new_diff_id(sha256_hex, layer_index, original_hex=None)` - Records
+  the new SHA256 for a modified layer. When `original_hex` is provided and
+  differs from `sha256_hex`, the mapping is also recorded in the cross-image
+  `_diff_id_map` for use by subsequent images in proxy mode.
 - `_skip_layer(layer_index)` - Advances the layer counter for unmodified
   layers (data=None, skipped by fetch_callback).
 - `_forward_buffered_config()` - Called by `finalize()` to update the config's
-  `rootfs.diff_ids` and forward it to the wrapped output. If no diff_ids
-  changed, the original config is forwarded unchanged.
+  `rootfs.diff_ids` and forward it to the wrapped output. For skipped layers
+  (not in `_new_diff_ids`), consults `_diff_id_map` to translate original
+  diff_ids to their filtered equivalents. If no diff_ids changed, the original
+  config is forwarded unchanged.
+
+**Cross-image diff_id mapping:** When the proxy processes child images that
+share base layers with a previously pushed parent, Docker only uploads new
+layers. The base layers already exist in the downstream registry in their
+filtered form. The `_diff_id_map` (a dict passed via `diff_id_map=` to filter
+constructors) maps `original_hex -> filtered_hex` across images. In proxy
+mode, `_ProxyState.diff_id_map` provides this shared dict. Non-proxy
+pipelines use an empty dict (no cross-image state needed).
 
 Content-modifying filters (ExcludeFilter, TimestampNormalizer) use these methods.
 Non-modifying filters (InspectFilter, SearchFilter) pass config through unchanged.
@@ -476,7 +488,8 @@ The proxy consists of four main components:
 
 - `_ProxyState` - Shared state between HTTP handler threads and the main
   process. Holds temp_dir, downstream_uri, filter_strs, layer_cache, in-progress
-  uploads, completed blobs, blob reference counts, and statistics. All mutations
+  uploads, completed blobs, blob reference counts, diff_id_map (cross-image
+  diff_id tracking for filtered layers), and statistics. All mutations
   protected by a lock. A processing semaphore limits concurrent manifest
   processing (configurable via `--concurrency`, default 4).
 
@@ -533,7 +546,9 @@ references them).
 - Blocking manifest processing provides natural backpressure and error
   propagation. Docker sees success or failure directly.
 - Each image gets a fresh pipeline (PipelineBuilder creates new instances),
-  so there is no cross-image state leakage in filters or outputs.
+  so there is no cross-image state leakage in filters or outputs -- except
+  for `diff_id_map`, which intentionally persists across images to track
+  how filters transform layer identities.
 - A shared `LayerCache` across images enables cross-image layer dedup:
   the first image pays full cost, subsequent images with shared base
   layers skip those layers entirely. `LayerCache` is internally

--- a/occystrap/filters/base.py
+++ b/occystrap/filters/base.py
@@ -41,7 +41,8 @@ class ImageFilter(ImageOutput, ABC):
     the actual layer content before forwarding it.
     """
 
-    def __init__(self, wrapped_output, temp_dir=None):
+    def __init__(self, wrapped_output, temp_dir=None,
+                 diff_id_map=None):
         """Wrap another output (or filter) to form a
         chain.
 
@@ -52,9 +53,17 @@ class ImageFilter(ImageOutput, ABC):
                 output (e.g., search-only mode).
             temp_dir: Directory for temporary files
                 (default: system temp directory).
+            diff_id_map: Shared dict mapping original
+                diff_id hex to filtered diff_id hex.
+                Used by the proxy to track how filters
+                transform layer identities across
+                images (default: empty dict).
         """
         self._wrapped = wrapped_output
         self.temp_dir = temp_dir
+        self._diff_id_map = (
+            diff_id_map if diff_id_map is not None
+            else {})
 
         # Config buffering for diff_id updates.
         # Content-modifying filters buffer the config
@@ -119,7 +128,8 @@ class ImageFilter(ImageOutput, ABC):
         self._buffered_config = element
 
     def _record_new_diff_id(
-            self, sha256_hex, layer_index):
+            self, sha256_hex, layer_index,
+            original_hex=None):
         """Record a new diff_id for a modified layer.
 
         Args:
@@ -128,12 +138,20 @@ class ImageFilter(ImageOutput, ABC):
                 (without 'sha256:' prefix).
             layer_index: The layer's position index,
                 or None for ordered delivery.
+            original_hex: Original diff_id hex before
+                filtering. When provided and different
+                from sha256_hex, records the mapping in
+                _diff_id_map for cross-image lookups.
         """
         idx = (layer_index
                if layer_index is not None
                else self._layer_counter)
         self._new_diff_ids[idx] = sha256_hex
         self._layer_counter += 1
+
+        if (original_hex is not None
+                and original_hex != sha256_hex):
+            self._diff_id_map[original_hex] = sha256_hex
 
     def _skip_layer(self, layer_index):
         """Advance the layer counter for an unmodified
@@ -182,6 +200,21 @@ class ImageFilter(ImageOutput, ABC):
             if idx < len(updated_ids):
                 updated_ids[idx] = (
                     'sha256:%s' % sha)
+
+        # Consult the cross-image diff_id_map for
+        # skipped layers whose base was filtered in
+        # a previous image push
+        for idx in range(len(updated_ids)):
+            if idx not in self._new_diff_ids:
+                old_id = updated_ids[idx]
+                if old_id.startswith('sha256:'):
+                    old_hex = old_id[7:]
+                else:
+                    old_hex = old_id
+                if old_hex in self._diff_id_map:
+                    updated_ids[idx] = (
+                        'sha256:%s'
+                        % self._diff_id_map[old_hex])
 
         if updated_ids == original_ids:
             self._buffered_config.data.seek(0)

--- a/occystrap/filters/exclude.py
+++ b/occystrap/filters/exclude.py
@@ -25,7 +25,8 @@ class ExcludeFilter(ImageFilter):
     __pycache__ folders, or other files before writing output.
     """
 
-    def __init__(self, wrapped_output, patterns, temp_dir=None):
+    def __init__(self, wrapped_output, patterns,
+                 temp_dir=None, diff_id_map=None):
         """Initialize the exclude filter.
 
         Args:
@@ -34,8 +35,12 @@ class ExcludeFilter(ImageFilter):
                 matched against the full path using fnmatch.
             temp_dir: Directory for temporary files (default:
                 system temp directory).
+            diff_id_map: Shared dict for cross-image diff_id tracking
+                (default: None).
         """
-        super().__init__(wrapped_output, temp_dir=temp_dir)
+        super().__init__(
+            wrapped_output, temp_dir=temp_dir,
+            diff_id_map=diff_id_map)
         self.patterns = patterns
 
     def _matches_exclusion(self, path):
@@ -133,7 +138,8 @@ class ExcludeFilter(ImageFilter):
             filtered_data, new_name = \
                 self._filter_layer(element.data)
             self._record_new_diff_id(
-                new_name, element.layer_index)
+                new_name, element.layer_index,
+                original_hex=element.name)
 
             try:
                 self._wrapped.process_image_element(

--- a/occystrap/filters/normalize_timestamps.py
+++ b/occystrap/filters/normalize_timestamps.py
@@ -25,7 +25,8 @@ class TimestampNormalizer(ImageFilter):
     files were originally created or modified.
     """
 
-    def __init__(self, wrapped_output, timestamp=0, temp_dir=None):
+    def __init__(self, wrapped_output, timestamp=0,
+                 temp_dir=None, diff_id_map=None):
         """Initialize the timestamp normalizer.
 
         Args:
@@ -35,8 +36,12 @@ class TimestampNormalizer(ImageFilter):
                 (default: 0).
             temp_dir: Directory for temporary files (default:
                 system temp directory).
+            diff_id_map: Shared dict for cross-image diff_id tracking
+                (default: None).
         """
-        super().__init__(wrapped_output, temp_dir=temp_dir)
+        super().__init__(
+            wrapped_output, temp_dir=temp_dir,
+            diff_id_map=diff_id_map)
         self.timestamp = timestamp
 
     def _normalize_layer(self, layer_data):
@@ -121,7 +126,8 @@ class TimestampNormalizer(ImageFilter):
             normalized_data, new_name = \
                 self._normalize_layer(element.data)
             self._record_new_diff_id(
-                new_name, element.layer_index)
+                new_name, element.layer_index,
+                original_hex=element.name)
 
             try:
                 self._wrapped.process_image_element(

--- a/occystrap/pipeline.py
+++ b/occystrap/pipeline.py
@@ -213,7 +213,9 @@ class PipelineBuilder:
         else:
             raise PipelineError('Unknown output scheme: %s' % uri_spec.scheme)
 
-    def build_filter(self, filter_spec, wrapped_output, image=None, tag=None):
+    def build_filter(self, filter_spec, wrapped_output,
+                     image=None, tag=None,
+                     diff_id_map=None):
         """Wrap an output with a filter.
 
         Args:
@@ -221,6 +223,8 @@ class PipelineBuilder:
             wrapped_output: The ImageOutput to wrap
             image: Image name (for search filter output)
             tag: Image tag (for search filter output)
+            diff_id_map: Shared dict for cross-image
+                diff_id tracking (proxy mode only).
 
         Returns:
             An ImageFilter wrapping the output.
@@ -237,7 +241,8 @@ class PipelineBuilder:
                 'timestamp', filter_spec.options.get('ts', 0))
             return TimestampNormalizer(
                 wrapped_output, timestamp=timestamp,
-                temp_dir=temp_dir)
+                temp_dir=temp_dir,
+                diff_id_map=diff_id_map)
 
         elif name == 'search':
             pattern = filter_spec.options.get('pattern')
@@ -265,7 +270,8 @@ class PipelineBuilder:
             patterns = [p.strip() for p in pattern_str.split(',')]
             return ExcludeFilter(
                 wrapped_output, patterns=patterns,
-                temp_dir=temp_dir)
+                temp_dir=temp_dir,
+                diff_id_map=diff_id_map)
 
         elif name == 'inspect':
             output_file = filter_spec.options.get('file')

--- a/occystrap/proxy.py
+++ b/occystrap/proxy.py
@@ -118,6 +118,12 @@ class _ProxyState:
         self.images_processed = 0
         self.images_failed = 0
 
+        # Cross-image diff_id mapping: original_hex -> filtered_hex.
+        # Populated by filters when they process layers, consulted
+        # when subsequent images skip layers that were already
+        # filtered for a previous image.
+        self.diff_id_map = {}
+
         # Pull-through statistics
         self.images_pulled = 0
         self.pull_cache_hits = 0
@@ -784,7 +790,8 @@ class ProxyRegistryHandler(
         for filter_spec in reversed(filter_specs):
             output = builder.build_filter(
                 filter_spec, output,
-                image=repo_name, tag=tag)
+                image=repo_name, tag=tag,
+                diff_id_map=self.state.diff_id_map)
 
         return output
 


### PR DESCRIPTION
When Docker pushes child images that share base layers with a previously pushed parent, it only uploads new layers. The proxy's filter pipeline skipped these base layers but left their original (unfiltered) diff_ids in the config. Since the downstream registry has the filtered versions, this caused "wrong diff id" errors on pull.

Add a cross-image diff_id_map to _ProxyState that tracks original -> filtered diff_id mappings. Filters record mappings when processing layers, and _forward_buffered_config consults the map for skipped layers to use the correct filtered diff_ids.

Prompt: Please investigate the occystrap code in shakenfist/occystrap and propose a fix there.