### PR TITLE
Widen renovate range strategy for grpc packages.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,20 @@
   "schedule": [
     "after 9pm"
   ],
+  "constraints": {
+    "python": ">=3.7"
+  },
   "packageRules": [
+    {
+      "description": "Group grpc packages together with widen strategy",
+      "matchPackagePatterns": [
+        "^grpcio",
+        "^googleapis-common-protos",
+        "^protobuf"
+      ],
+      "groupName": "grpc packages",
+      "rangeStrategy": "widen"
+    },
     {
       "description": "Automatically merge minor and patch-level updates",
       "matchUpdateTypes": [
@@ -19,9 +32,6 @@
       "automerge": false
     }
   ],
-  "constraints": {
-    "python": ">=3.7"
-  },
   "minimumReleaseAge": "3 days",
   "rollbackPrs": true
 }


### PR DESCRIPTION
Use rangeStrategy "widen" for grpc packages so renovate only creates PRs for new major versions, avoiding
unnecessary churn when dependencies use >= constraints.

Prompt: For each of shakenfist/agent-python, client-python, client-python-k3s, clingwrap, and occystrap: update renovate.json to use widen rangeStrategy for grpc packages.