### PR TITLE
Expand bug-tracker guidance in plan template.

### DIFF
--- a/PLAN-TEMPLATE.md
+++ b/PLAN-TEMPLATE.md
@@ -84,8 +84,11 @@ chosen to defer to here so that we don't forget them.
 
 ### Bugs fixed during this work
 
-This section should list any bugs we encounter during development
-that we fixed.
+This section should list any bugs we encounter during
+development that we fixed. You should also scan the relevant
+github bug tracker to see if there are any directly related
+bugs that we should either resolve as part of this master
+plan, or at least be aware of when planning.
 
 ### Back brief
 


### PR DESCRIPTION
Update the "Bugs fixed during this work" section of the planning template to instruct that the relevant GitHub bug tracker be scanned for directly related bugs, so they can either be resolved as part of the master plan or at least be accounted for during planning.