### PR TITLE
Retain pushed blobs for the proxy session.

### DIFF
--- a/occystrap/proxy.py
+++ b/occystrap/proxy.py
@@ -60,7 +60,7 @@ class _ProxyState:
     """Shared state between the proxy HTTP handler
     threads and the main process.
 
-    All mutations to uploads, blobs, blob_refcounts,
+    All mutations to uploads, blobs,
     active_processing, pull_locks, downstream_images,
     and statistics must be protected by the lock.
     """
@@ -87,13 +87,15 @@ class _ProxyState:
 
         # In-progress uploads: uuid -> {path, offset}
         self.uploads = {}
-        # Completed blobs: digest_hex -> temp file path
+        # Completed blobs: digest_hex -> temp file path.
+        # Blobs are retained for the lifetime of the proxy
+        # (cleaned up at shutdown) rather than deleted after the
+        # manifest that referenced them. A blob uploaded by one
+        # push must stay available to other concurrent pushes that
+        # share it -- e.g. a common base layer: the client is told
+        # via HEAD that the blob already exists and skips
+        # re-uploading it, so the proxy must keep it until it stops.
         self.blobs = {}
-        # Blob reference counts: digest_hex -> int.
-        # Incremented when a manifest references a blob,
-        # decremented when processing completes. Blobs
-        # are only deleted when refcount reaches 0.
-        self.blob_refcounts = {}
         # Manifests successfully pushed to us this session, kept
         # only when no upstream is configured (push-only mode). A
         # push client (docker/buildkit) verifies the manifest it
@@ -669,16 +671,11 @@ class ProxyRegistryHandler(
         referenced_blobs.add(
             config_digest.split(':')[1])
 
-        # Under lock: increment refcounts, snapshot
-        # blob paths, and mark processing as active.
-        # Refcounts must be incremented before
-        # acquiring the semaphore so blobs are
-        # protected even while waiting for a slot.
+        # Under lock: snapshot the paths of the blobs this manifest
+        # references and mark processing as active. Blobs are
+        # retained for the session, so the snapshot stays valid for
+        # the duration of processing without any refcounting.
         with self.state.lock:
-            for hex_digest in referenced_blobs:
-                rc = self.state.blob_refcounts
-                rc[hex_digest] = (
-                    rc.get(hex_digest, 0) + 1)
             blobs_snapshot = {
                 k: v
                 for k, v in self.state.blobs.items()
@@ -708,26 +705,11 @@ class ProxyRegistryHandler(
         finally:
             self.state.processing_semaphore.release()
 
-            # Decrement refcounts and clean up blobs
-            # that are no longer referenced by any
-            # in-flight manifest processing.
+            # Blobs are intentionally retained for the session (see
+            # _ProxyState.blobs) so concurrent pushes sharing a
+            # layer can still find it; they are unlinked when the
+            # proxy shuts down.
             with self.state.lock:
-                for hex_digest in referenced_blobs:
-                    rc = self.state.blob_refcounts
-                    count = rc.get(hex_digest, 1) - 1
-                    if count <= 0:
-                        rc.pop(hex_digest, None)
-                        blob_path = (
-                            self.state.blobs.pop(
-                                hex_digest, None))
-                        if blob_path:
-                            try:
-                                os.unlink(blob_path)
-                            except OSError:
-                                pass
-                    else:
-                        rc[hex_digest] = count
-
                 self.state.active_processing -= 1
 
         # Send HTTP response after cleanup so state

--- a/occystrap/tests/test_proxy.py
+++ b/occystrap/tests/test_proxy.py
@@ -414,10 +414,12 @@ class TestProxyManifest(unittest.TestCase):
 
     @mock.patch(
         'occystrap.proxy.PipelineBuilder')
-    def test_blobs_cleaned_up_after_processing(
+    def test_blobs_retained_after_processing(
             self, mock_builder_cls):
-        """Blobs referenced by a manifest are cleaned
-        up after processing."""
+        """Blobs referenced by a manifest are retained
+        after processing (cleaned up only at proxy
+        shutdown), so a concurrent push sharing a layer
+        can still find it."""
         mock_builder = mock.MagicMock()
         mock_builder_cls.return_value = mock_builder
 
@@ -449,8 +451,9 @@ class TestProxyManifest(unittest.TestCase):
             data=manifest_bytes)
         self.assertEqual(r.status_code, 201)
 
-        # Blobs should be cleaned up
-        self.assertEqual(len(self.state.blobs), 0)
+        # Blobs are retained for the session, not deleted
+        # after the manifest that referenced them.
+        self.assertTrue(len(self.state.blobs) > 0)
 
     @mock.patch(
         'occystrap.proxy.PipelineBuilder')
@@ -603,22 +606,25 @@ class TestProxyPostPushVerification(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.content, manifest_bytes)
 
-    def test_head_blob_404_after_cleanup(self):
-        # Blobs are cleaned from disk after processing. We must
-        # NOT advertise them as present afterwards: a push client
-        # uses HEAD blob as a pre-upload existence check, and a
-        # false 200 would make it skip an upload the proxy can no
-        # longer satisfy. Existence is only reported while the
-        # blob is still on disk (verification needs the manifest,
-        # not the blobs).
+    def test_head_blob_200_retained_after_processing(self):
+        # Blobs are retained for the session, so a HEAD after
+        # processing correctly reports the blob as present -- and
+        # because it is genuinely still on disk, a concurrent push
+        # that skips re-uploading it can still be satisfied. (This
+        # is safe precisely because retention keeps the bytes; the
+        # earlier hazard was advertising a blob that had been
+        # deleted.)
         _, config_hex = self._push_image(
             'test/img', 'latest')
-        self.assertEqual(len(self.state.blobs), 0)
+        self.assertTrue(len(self.state.blobs) > 0)
 
         r = self.sess.head(
             '%s/v2/test/img/blobs/sha256:%s'
             % (self.base, config_hex))
-        self.assertEqual(r.status_code, 404)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.headers.get('Docker-Content-Digest'),
+            'sha256:%s' % config_hex)
 
     def test_unknown_manifest_still_404(self):
         # An image we never received must still 404.
@@ -894,10 +900,6 @@ class TestProxyState(unittest.TestCase):
         self.assertFalse(
             state.processing_semaphore
             .acquire(blocking=False))
-
-    def test_blob_refcounts_initialized(self):
-        state = _ProxyState()
-        self.assertEqual(state.blob_refcounts, {})
 
     def test_active_processing_initialized(self):
         state = _ProxyState()
@@ -1281,8 +1283,6 @@ class TestBlobRefcounting(unittest.TestCase):
                     .MEDIA_TYPE_DOCKER_MANIFEST_V2
             })
         self.assertEqual(r.status_code, 201)
-        self.assertEqual(
-            self.state.blob_refcounts, {})
         self.assertEqual(
             self.state.active_processing, 0)
 


### PR DESCRIPTION
The proxy deleted each received blob as soon as the manifest that referenced it finished processing (refcounted per manifest). Under concurrent pushes that share a layer this strands later pushes:

  push A: upload L ─► manifest ─► process ─► cleanup (delete L)
  push B:      HEAD L → 200 (it is A's, still on disk) → skip upload
               ............................ manifest → L gone → 500
               "Layer blob <L> not received"

Because do_HEAD answers from the global blob store, B is told the shared layer already exists and skips re-uploading it; A then deletes it on its own cleanup, before B's manifest is processed. A and B's reference lifetimes never overlap, so per-manifest refcounting cannot protect the blob. This broke kolla-build, whose images share base layers and are pushed concurrently (every image inheriting a given base layer failed with "not received").

Retain received blobs for the lifetime of the proxy and unlink them only at shutdown (the shutdown path already did this). A blob advertised via HEAD then stays available to whichever concurrent push relies on it. The per-manifest refcount machinery (blob_refcounts) existed only to drive that eager deletion and is removed. The proxy is a short-lived per-build sidecar, so the retained set is bounded by the run's unique layers and reclaimed when it stops.

Reproduced with 12 concurrent shared-layer buildx --push builds (2-3 failed before, 0 after); also verified end to end against the release that shipped the earlier fixes.

Prompt: A kerbside-patches CI image build still failed after the push-only verification fix, with occystrap returning 500 "Layer blob not received" for base layers shared across concurrently-built kolla images. Root-caused to eager per-manifest blob deletion racing concurrent shared-layer pushes; fix by retaining blobs for the proxy session.


Assisted-By: Claude Opus 4.8 (1M context, high effort)