### PR TITLE
Embed the comment-proportion shared block

### DIFF
--- a/PUSH-AUDIT.md
+++ b/PUSH-AUDIT.md
@@ -13,6 +13,28 @@ before I push:
  * Please ensure all source code is wrapped at 120 characters.
  * Use single quotes for strings, double quotes for docstrings.
 
+<!-- shared-block: comment-proportion v1 -->
+Comment proportion (shared block; do not edit -- the canonical
+copy lives in shakenfist/development at
+`templates/shared-blocks/comment-proportion.md`):
+
+- A comment or docstring earns its length by saying what the code
+  cannot: the contract, the units, the failure modes, the reason a
+  surprising choice is correct. Restating the code in prose is not
+  documentation.
+- Treat as candidates any added comment or docstring that is longer
+  than the code it documents, and any comment block over roughly
+  fifteen lines attached to a body under ten. These are candidates,
+  not verdicts -- a subtle algorithm, a public API contract, or a
+  hard-won bug explanation can justify the length.
+- Where the length is not justified the finding is advisory, and
+  the fix is to cut the restatement rather than delete the comment:
+  keep the why, drop the line-by-line narration of the what.
+- Prose that documents user-visible behaviour rather than the
+  implementation usually belongs in `docs/`, with the comment
+  reduced to a pointer.
+<!-- shared-block-end -->
+
 ## Style conformance
 
  * Does the code follow the project conventions in `CLAUDE.md`?


### PR DESCRIPTION
Embeds the new `comment-proportion` shared block from
[shakenfist/development](https://github.com/shakenfist/development/blob/main/templates/shared-blocks/comment-proportion.md)
into the code-quality review section of `PUSH-AUDIT.md`.

## Why

A pull request landed carrying a method comment several times
longer than the method itself, and nothing in the pre-push audit
asked about that. The canonical block now exists in
`templates/shared-blocks/`, and the `push-audit` consistency check
requires it, so this repository is currently non-compliant.

## Why it is judgment rather than a grep

Comment volume has no honest mechanical threshold -- the same
twenty-line docstring is right on a lock-ordering contract and
wrong on a three-line accessor. The block therefore briefs the
code-quality judgment agent: comment blocks longer than the code
they document are *candidates* rather than verdicts, the finding is
advisory, and the fix is to cut the restatement rather than to
delete the comment.

## Notes

- The block is pasted verbatim, markers included, as the shared
  block mechanism requires. Do not edit it here -- fix the
  canonical copy in `shakenfist/development` and bump its version.
- Documentation-only change; no code paths are touched.
- `pre-commit run --all-files` passes in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cqzpHxWy4qB1JT8Twdo7n