### PR TITLE
Use the shared automated review workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -93,24 +93,18 @@ jobs:
 
   automated_reviewer:
     name: "Automated reviewer"
+    # The needs: list is the "review only once CI has passed" gate:
+    # a job skipped because a dependency failed never starts the
+    # reusable workflow. Everything else about the reviewer --
+    # runner, timeout, fork restriction, bot-commit check --
+    # lives in the shared workflow so it stays in step with the
+    # rest of the fleet.
+    needs: [functional]
+    # A cross-repository reusable workflow cannot grant itself more
+    # token scope than its caller has, so the permissions go here.
     permissions:
       contents: read
       pull-requests: write
       issues: write
-    runs-on: [self-hosted, claude-code]
-    needs: [functional]
-    if: github.event_name == 'pull_request'
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-reviewer
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Run automated reviewer
-        uses: shakenfist/actions/review-pr-with-claude@main
-        with:
-          pr-number: ${{ github.event.pull_request.number }}
+    uses: shakenfist/actions/.github/workflows/pr-auto-review.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-address-comments.yml
+++ b/.github/workflows/pr-address-comments.yml
@@ -45,6 +45,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please address comments')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
     outputs:
       authorized: ${{ steps.trigger.outputs.authorized }}
       pr_ref: ${{ steps.trigger.outputs.pr-ref }}

--- a/.github/workflows/pr-fix-tests.yml
+++ b/.github/workflows/pr-fix-tests.yml
@@ -20,6 +20,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please attempt to fix')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
     outputs:
       authorized: ${{ steps.trigger.outputs.authorized }}
       pr_ref: ${{ steps.trigger.outputs.pr-ref }}

--- a/.github/workflows/pr-re-review.yml
+++ b/.github/workflows/pr-re-review.yml
@@ -20,6 +20,10 @@ jobs:
       contains(github.event.comment.body, '@shakenfist-bot please re-review')
     runs-on: [self-hosted, claude-code]
     name: "Re-review PR"
+    # A review typically takes a handful of minutes. Without this the
+    # job inherits the six hour GitHub default, so a wedged Claude run
+    # would hold a scarce claude-code runner for the rest of the day.
+    timeout-minutes: 60
 
     steps:
       - name: Check commenter permissions

--- a/.github/workflows/pr-retest.yml
+++ b/.github/workflows/pr-retest.yml
@@ -24,6 +24,8 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@shakenfist-bot please retest')
     runs-on: [self-hosted, static]
+    # Just a few gh API calls, so anything beyond this is a hang.
+    timeout-minutes: 10
 
     steps:
       - name: Handle trigger


### PR DESCRIPTION
The automatic PR review has until now been an "automated_reviewer" job
written out in full in this repository's CI workflow, copied from a
snippet in the development repository's README. Eight projects each
carried a copy and they had drifted from one another. None of them set
timeout-minutes, so a wedged Claude Code run could hold a scarce
claude-code runner for GitHub's six hour default.

The job body now lives once, in
shakenfist/actions/.github/workflows/pr-auto-review.yml. What stays
here is the part which is genuinely per-project: the needs: list
naming this project's test jobs, which is what gates the review on CI
passing. A job skipped because a dependency failed never starts the
reusable workflow.

Adopting the shared workflow brings this project:

* A 60 minute timeout on the review. Real reviews finish in three to
  six minutes.
* The same-repository restriction. The reviewer runs Claude Code with
  --dangerously-skip-permissions while holding a token with
  pull-requests: write and issues: write, and is fed the PR diff,
  which is untrusted input, so a fork PR would put an attacker's text
  in front of a write-capable token.
* A bot-commit check which also recognises noreply@anthropic.com, the
  address a Claude Code commit made on a runner is authored as. Only
  clingwrap's copy caught that address before.

This project never had a check-bot-commit job, so its reviewer could
be triggered by the automated fixers' own commits. Adopting the shared
workflow adds that gate.

While here, bring the rest of the Claude Code workflow timeouts into line
with the templates: 60 minutes on the re-review, 10 on the retest trigger,
10 on the address-comments trigger and 10 on the fix-tests trigger.

Validated with each project's own `pre-commit` on the changed files, and by diffing actionlint findings before and after so pre-existing noise is not mistaken for a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
